### PR TITLE
Set npm registry in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Add a project-level npm registry configuration pointing installs to the public npm registry.