### PR TITLE
Add Cypress TypeScript config reference

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./cypress/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
Include the Cypress TypeScript configuration in the root tsconfig references. This ensures Cypress test files inherit the project's TypeScript settings and maintain consistent type checking across the codebase.