### PR TITLE
Format Codacy coverage step spacing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -39,6 +39,7 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/example-angular-app/lcov.info
           language: 'TypeScript'
+
       - name: Upload HTML coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@v1.3.0
         with:


### PR DESCRIPTION
Add a blank line between the lcov and HTML Codacy coverage upload steps in the GitHub Actions workflow to improve readability.