### PR TITLE
Update .gitignore for Playwright artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,20 +32,23 @@ yarn-error.log
 /.angular/cache
 .sass-cache/
 /connect.lock
-
+/coverage
 /libpeerconnection.log
 testem.log
 /typings
+__screenshots__/
 
 # System files
 .DS_Store
 Thumbs.db
 
-# Test Reports
-/coverage
-/test-reports
-/test-results
-/playwright-report
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/
 
 # Codacy
 .codacy/


### PR DESCRIPTION
Refines ignore rules by reorganizing test-related entries and adding Playwright-specific outputs and caches (`/blob-report/`, `/playwright/.cache/`, `/playwright/.auth/`) plus `__screenshots__/`. It also keeps `/coverage` ignored and adds `node_modules/` under the Playwright section for local test runs.