### PR TITLE
Simplify dependabot grouping config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,60 +18,22 @@ updates:
       - dependency-type: 'all'
     open-pull-requests-limit: 5
     groups:
-      angular-version-updates:
+      safe-version-updates:
         applies-to: version-updates
         patterns:
-          - '*angular*'
-          - 'ngx*'
+          - '*'
         update-types:
-          - 'patch'
           - 'minor'
-      angular-security-updates:
+          - 'patch'
+      safe-security-updates:
         applies-to: security-updates
         patterns:
-          - '*angular*'
-          - 'ngx*'
-        update-types:
-          - 'patch'
-          - 'minor'
-      production-version-updates:
-        applies-to: version-updates
-        dependency-type: production
-        update-types:
-          - 'patch'
-          - 'minor'
-      production-security-updates:
-        applies-to: security-updates
-        dependency-type: production
-        update-types:
-          - 'patch'
-          - 'minor'
-      development-version-updates:
-        applies-to: version-updates
-        dependency-type: development
-        update-types:
-          - 'patch'
-          - 'minor'
-      development-security-updates:
-        applies-to: security-updates
-        dependency-type: development
+          - '*'
         update-types:
           - 'patch'
           - 'minor'
     ignore:
-      - dependency-name: '@playwright/test'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/iframe-resizer'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/node'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '*angular*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '*eslint*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'iframe-resizer'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'ngx*'
+      - dependency-name: '*'
         update-types: ['version-update:semver-major']
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major', 'version-update:semver-minor']


### PR DESCRIPTION
Consolidate multiple granular dependency groups into two catch-all groups (safe-version-updates and safe-security-updates) covering all packages. Replace individual major-version ignore rules with a single wildcard ignore, keeping the TypeScript minor+major ignore.