### PR TITLE
Add the ability to resize columns

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npm run lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,13 +279,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2200.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.7.tgz",
-      "integrity": "sha512-t03YYe5amlcpsX5gpMGi96kpBNTMKY7/rJsRDNO3v98mSy7kzNXlgzy/jyfdFev7AJusuwVM5TKVsUAgQxCgCw==",
+      "version": "0.2200.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.8.tgz",
+      "integrity": "sha512-LFKK2v96nO0ESM9nftlCkTy+O/66AxNkwUpG+Q1er7LLNR2S8UReZnQ1/RhMkldCWxsmp2rQzdgHWnubaY/ZfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.7",
+        "@angular-devkit/core": "22.0.8",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.7.tgz",
-      "integrity": "sha512-r8XiflsVYcsvWp+zVvaNv5GsDoihaZ2OwWfn++N6YqTUZLcqDzqhsxeNk60sJ5V+Jn4ck1aKF4A9flmvSY+tpQ==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.8.tgz",
+      "integrity": "sha512-Hnr4SCkxQM+xtq4uERC09qwTZpt97t4CwDZYzv/HbQA4pMYDfTxvIRHCyl+UHf4NbkC7ZVgyiab+KzTfuc609Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -326,13 +326,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.7.tgz",
-      "integrity": "sha512-bKgnBB0LPAj44uVXfW0UO1rQBb3HGXDZxa1bLtESr/KCK4j5iiaXlHqvJjc/z0em1Ds9WNQOfNXjV3IdJo9sSw==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.8.tgz",
+      "integrity": "sha512-9WjTKnW/5oIw4hNNcd0rSYtgHRrHKKAkG6+bdLqTCY68P2brO2yEJM2JjYtMYk/WSovknb0GxUP4n3dY3IxPug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.7",
+        "@angular-devkit/core": "22.0.8",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.4.0",
@@ -467,14 +467,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.7.tgz",
-      "integrity": "sha512-cm/QJmrIgsjzZJeBeqeNwgdgK6BGBKk7ca21jnSsrwlae3F9u1E8cImFbLeZSjEGghx4wFUacFDG+6lFEICntw==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.8.tgz",
+      "integrity": "sha512-QJVVTROVb27Ixk+RU4FSKwwyRbLdtNH20zFm1CwOKzA0wQHrWfxHTqlwMhnTOsOt5Cb3eX+6IjDXoGmAfJ81mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2200.7",
+        "@angular-devkit/architect": "0.2200.8",
         "@babel/core": "7.29.7",
         "@babel/helper-annotate-as-pure": "7.29.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -496,7 +496,7 @@
         "semver": "7.7.4",
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.16",
-        "vite": "7.3.5",
+        "vite": "7.3.6",
         "watchpack": "2.5.1"
       },
       "engines": {
@@ -515,7 +515,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.0.7",
+        "@angular/ssr": "^22.0.8",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -585,19 +585,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.7.tgz",
-      "integrity": "sha512-5r+fgP8ARnXZeylAGt5BuToVcR8Vn2QQZ6dPMe7V9o4NdvJqqOKmE7fEiRe7KaxIx5WSDhuAhgW9t+scLZQbvw==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.8.tgz",
+      "integrity": "sha512-kefbTsmf7sEmW5g3NIRvH0OrM18I1jjZHlB9KABgRQhsDfD/WgfLt6aSLJQeFDlAOs+ehDPzzOwd9l48wyBlFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2200.7",
-        "@angular-devkit/core": "22.0.7",
-        "@angular-devkit/schematics": "22.0.7",
+        "@angular-devkit/architect": "0.2200.8",
+        "@angular-devkit/core": "22.0.8",
+        "@angular-devkit/schematics": "22.0.8",
         "@inquirer/prompts": "8.4.2",
         "@listr2/prompt-adapter-inquirer": "4.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.0.7",
+        "@schematics/angular": "22.0.8",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.52.0",
         "ini": "6.0.0",
@@ -1375,9 +1375,9 @@
       }
     },
     "node_modules/@csstools/selector-resolve-nested": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
-      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.1.tgz",
+      "integrity": "sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==",
       "dev": true,
       "funding": [
         {
@@ -4330,14 +4330,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.7.tgz",
-      "integrity": "sha512-/GVLhB5zaxYGIaC4GFfsfk81SDq9ht0HbEHhHB+t1SqNPV8gnULDV2ZE0Cg+LGj+3YnPtSwpb7tS0vaHUcihVg==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.8.tgz",
+      "integrity": "sha512-zD2WLe15SoKYyBZH1GTLLaVABNNObHkH4soQqXb9agN6zkrpE0naeWaBSFSWD+95VKCiMZl8LkiOXvK+6b8S6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.7",
-        "@angular-devkit/schematics": "22.0.7",
+        "@angular-devkit/core": "22.0.8",
+        "@angular-devkit/schematics": "22.0.8",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -5844,16 +5844,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -9733,9 +9733,9 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.1.tgz",
-      "integrity": "sha512-FnHWpSe5cPRtrDG+soOuNdBxb4XQb2gN5EqpEWKdweyqyOfpl4QSjbrz3ilcIf0WXmkiNQGZZRQ23R5YtB3TEw==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.2.0.tgz",
+      "integrity": "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10336,13 +10336,17 @@
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/meow": {
@@ -14627,13 +14631,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -14699,490 +14703,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,13 +279,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2200.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.6.tgz",
-      "integrity": "sha512-wTjUfiT5iEMc9+9z2zo1QGtzLpXk5Xx0bV6/zTO4n6+BCC0qReuYnIYt0iJCh649Q0vHq5++0zmZZK0KyXVMZQ==",
+      "version": "0.2200.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.7.tgz",
+      "integrity": "sha512-t03YYe5amlcpsX5gpMGi96kpBNTMKY7/rJsRDNO3v98mSy7kzNXlgzy/jyfdFev7AJusuwVM5TKVsUAgQxCgCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.6",
+        "@angular-devkit/core": "22.0.7",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.6.tgz",
-      "integrity": "sha512-uAZ7TPn+8sDZcFtiM5nQpmqaR9lspLAf7RY7t7TXYP794001khRf+F/AhmONxmgFPWY01+eeJSvBx+FEnHCb0A==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.7.tgz",
+      "integrity": "sha512-r8XiflsVYcsvWp+zVvaNv5GsDoihaZ2OwWfn++N6YqTUZLcqDzqhsxeNk60sJ5V+Jn4ck1aKF4A9flmvSY+tpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -326,13 +326,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.6.tgz",
-      "integrity": "sha512-7bSiye4UrxvhYvYp1YIpVSVOFQZ75EXP3EE5/ShM3cPNtUTdXJiwHkD8SiLHNhPTB6Mzrq5tp1YlAXXRg/WgLw==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.7.tgz",
+      "integrity": "sha512-bKgnBB0LPAj44uVXfW0UO1rQBb3HGXDZxa1bLtESr/KCK4j5iiaXlHqvJjc/z0em1Ds9WNQOfNXjV3IdJo9sSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.6",
+        "@angular-devkit/core": "22.0.7",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.4.0",
@@ -467,16 +467,16 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.6.tgz",
-      "integrity": "sha512-mIp1snH1haw4pKiJwUmKyp9f31NRUTeUwqrl9W59X3Iv54egOnD1EdCc0jsW7WJVr/JHRZYVt/ooFelUB8uV8g==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.7.tgz",
+      "integrity": "sha512-cm/QJmrIgsjzZJeBeqeNwgdgK6BGBKk7ca21jnSsrwlae3F9u1E8cImFbLeZSjEGghx4wFUacFDG+6lFEICntw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2200.6",
-        "@babel/core": "7.29.0",
-        "@babel/helper-annotate-as-pure": "7.27.3",
+        "@angular-devkit/architect": "0.2200.7",
+        "@babel/core": "7.29.7",
+        "@babel/helper-annotate-as-pure": "7.29.7",
         "@babel/helper-split-export-declaration": "7.24.7",
         "@inquirer/confirm": "6.0.12",
         "@vitejs/plugin-basic-ssl": "2.3.0",
@@ -515,7 +515,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.0.6",
+        "@angular/ssr": "^22.0.7",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.0.4.tgz",
-      "integrity": "sha512-XaH1ff9tOn4acPh0zWbrmJznfZqZ0KZkw5+DM5BIeM9URmAOI8xdZWmVNyaUpVSmriANFjeGZS+Sfat9S6hLOg==",
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.0.5.tgz",
+      "integrity": "sha512-qy1scYkkhedGxrU2GjOUoh76xjsxCDOODWdVfg4aXLXG7RBIH6hOuKdcNpR/sWhfSdY02a11QYRN2CqoqWDvZQ==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -585,19 +585,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.6.tgz",
-      "integrity": "sha512-/sEN1hVcywSML+yWrr/T7gbuGfIrZwKC+WhiOv5GksSQVUrSujWnMX4meRJ5ocG/Ie8UN48LJ7LVDsm32NBt1A==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.7.tgz",
+      "integrity": "sha512-5r+fgP8ARnXZeylAGt5BuToVcR8Vn2QQZ6dPMe7V9o4NdvJqqOKmE7fEiRe7KaxIx5WSDhuAhgW9t+scLZQbvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2200.6",
-        "@angular-devkit/core": "22.0.6",
-        "@angular-devkit/schematics": "22.0.6",
+        "@angular-devkit/architect": "0.2200.7",
+        "@angular-devkit/core": "22.0.7",
+        "@angular-devkit/schematics": "22.0.7",
         "@inquirer/prompts": "8.4.2",
         "@listr2/prompt-adapter-inquirer": "4.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.0.6",
+        "@schematics/angular": "22.0.7",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.52.0",
         "ini": "6.0.0",
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.0.6.tgz",
-      "integrity": "sha512-+sC0W0FWGeZ/HKUhueCBX8kXdFQDlStbUSK6WF/32igfNYR/PdUrp2L5bU7q654yjxnMzFWDAB+Uvzv6YI/cQg==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.0.7.tgz",
+      "integrity": "sha512-iun8auXVnpPzunhtaPHMF0gSpByxv7kHhG3Nb6r34eJITW5p06LYyZbkAnl5ERArmgQvEV4pTjoo7ZTK3cJzzw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -631,14 +631,14 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "22.0.6",
+        "@angular/core": "22.0.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.0.6.tgz",
-      "integrity": "sha512-iFHsXOA14TsxK4jowmGfogI9Jb0ApL3z8EGTGvKMialqtw088HYjwJP1LT4OlO/wgmjSTq2peZ19jLPuhevNvw==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.0.7.tgz",
+      "integrity": "sha512-zhFPKYJzpml5bt58DkJq8S6S2bSJBomebgLYtUvZNLdQMicd5qmRGX6I3LO7Jd+HgjB2Flne/sloI+Jcyz1aOQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.0.6.tgz",
-      "integrity": "sha512-HPiceCIEyIcTmOuIFiyqu04kbLoJhSUavcOy/kzJkJ2OPXtPvGKaimC4lgs0C86uFy4P6rj6PDITBe3AVHkMTA==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.0.7.tgz",
+      "integrity": "sha512-/3HjBJUzljyPgb77R679+FN1+27xIGuLCAhuqzfj6DxX5WJOOmQOWE/k12eAZujE+ZypSf8ZGkfaukZV43FwoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -671,7 +671,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.0.6",
+        "@angular/compiler": "22.0.7",
         "typescript": ">=6.0 <6.1"
       },
       "peerDependenciesMeta": {
@@ -680,58 +680,10 @@
         }
       }
     },
-    "node_modules/@angular/compiler-cli/node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@angular/core": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.0.6.tgz",
-      "integrity": "sha512-9AYGxmZlJhjLSepZaF/cn1LTC9xRHpUPtXlyyJdauTb4f77X/P0kVdmADztgF1Qy5oMd1V9UKebAe81gmqOH2g==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.0.7.tgz",
+      "integrity": "sha512-A5xKJx5wuuZfeJhShyZvbgicYtT3Jpw/5wJd1cfrcKU+i63CagRIg9jSktTW/e+2hxG1tIQrfKQUGeclmsAUUA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -740,7 +692,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.0.6",
+        "@angular/compiler": "22.0.7",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -754,9 +706,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.0.6.tgz",
-      "integrity": "sha512-pZGMk1TvT+m8z2ZGm90W0sBlo6fhtMAA2baZbMt3HbGRmY23vZv1Orv9npX3Z6a9CCNDY3XBMBvkuj8g7vde9Q==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.0.7.tgz",
+      "integrity": "sha512-24ldrCORVCi3SoqtshjD8PcT5zg4aIXy9p8+GsO/c3yuhAouVOwL4z1/btNdo7UZv1asyaT3w4lgzprN8TGpjA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -767,22 +719,22 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.0.6",
-        "@angular/core": "22.0.6",
-        "@angular/platform-browser": "22.0.6",
+        "@angular/common": "22.0.7",
+        "@angular/core": "22.0.7",
+        "@angular/platform-browser": "22.0.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.0.4.tgz",
-      "integrity": "sha512-htOFlTwMtcB9J4q6yPD9jJIQVJ5LfRub+KAiD4D7UU1iaCknpNuQKRfLrZh/mEdOVACI52jHAOXS3+eTkloXcQ==",
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.0.5.tgz",
+      "integrity": "sha512-A0SnDMvWQBxv3dB2w33GXwuo1/puKtFe8ZMQmIiurS5bbTQpV7UHAM0pWzg7L4DG2cvaH4WZGRPfNG3f8fh+yA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "22.0.4",
+        "@angular/cdk": "22.0.5",
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
         "@angular/forms": "^22.0.0 || ^23.0.0",
@@ -791,9 +743,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.0.6.tgz",
-      "integrity": "sha512-DyyYRx4jXlfaenf0mwsp9jcIak/c17QCFgJKA7OauSkQnk3dL+voMYEwdigfnTIUdw+2Y9wYDywLeuM6NychNQ==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.0.7.tgz",
+      "integrity": "sha512-iCuREIWRnDCsd7mI5vn5ovXjcSwseWR4qfd+zo6QUrY2O9zkUNV79YuCqVjSzvWyvU2rtR5iRBvpB5JQgBELeg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -802,9 +754,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "22.0.6",
-        "@angular/common": "22.0.6",
-        "@angular/core": "22.0.6"
+        "@angular/animations": "22.0.7",
+        "@angular/common": "22.0.7",
+        "@angular/core": "22.0.7"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -813,9 +765,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.0.6.tgz",
-      "integrity": "sha512-s0BErBBadCXlvilob8aWke4H1FRlXDbnDfyYkjW6RkUaGQ4jzeEAzH56KsG2hf8NtBtYwkRlsLfOX9s5sPwm6w==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.0.7.tgz",
+      "integrity": "sha512-uMh+2S5y5Z6hTeFL85tDehfqAwVYjnTlHxpCrW+75RD4Z+rLl0/ff2ag3bXknzNyg0Q9LPOH6t/eCcQYajNOQQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -824,9 +776,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.0.6",
-        "@angular/core": "22.0.6",
-        "@angular/platform-browser": "22.0.6",
+        "@angular/common": "22.0.7",
+        "@angular/core": "22.0.7",
+        "@angular/platform-browser": "22.0.7",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -907,21 +859,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -972,13 +924,13 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3639,9 +3591,9 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3650,7 +3602,7 @@
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
         "node-addon-api": "^7.0.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -3660,25 +3612,24 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.6",
-        "@parcel/watcher-darwin-arm64": "2.5.6",
-        "@parcel/watcher-darwin-x64": "2.5.6",
-        "@parcel/watcher-freebsd-x64": "2.5.6",
-        "@parcel/watcher-linux-arm-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm-musl": "2.5.6",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm64-musl": "2.5.6",
-        "@parcel/watcher-linux-x64-glibc": "2.5.6",
-        "@parcel/watcher-linux-x64-musl": "2.5.6",
-        "@parcel/watcher-win32-arm64": "2.5.6",
-        "@parcel/watcher-win32-ia32": "2.5.6",
-        "@parcel/watcher-win32-x64": "2.5.6"
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
       "cpu": [
         "arm64"
       ],
@@ -3697,9 +3648,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
       "cpu": [
         "arm64"
       ],
@@ -3718,9 +3669,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
       "cpu": [
         "x64"
       ],
@@ -3739,9 +3690,9 @@
       }
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
       "cpu": [
         "x64"
       ],
@@ -3760,9 +3711,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
       "cpu": [
         "arm"
       ],
@@ -3784,9 +3735,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
       "cpu": [
         "arm"
       ],
@@ -3808,9 +3759,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
       "cpu": [
         "arm64"
       ],
@@ -3832,9 +3783,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
       "cpu": [
         "arm64"
       ],
@@ -3856,9 +3807,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
       "cpu": [
         "x64"
       ],
@@ -3880,9 +3831,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
       "cpu": [
         "x64"
       ],
@@ -3904,9 +3855,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
       "cpu": [
         "arm64"
       ],
@@ -3924,31 +3875,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
       "cpu": [
         "x64"
       ],
@@ -4400,14 +4330,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.0.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.6.tgz",
-      "integrity": "sha512-pZP52HlQaILmFKK4/iA2OyQ7mMP2V/K6z3gxbykWgXk/MNJ605PWaptHZOuvAAp+0qsFWJbj0MLmDdR3yMhdMQ==",
+      "version": "22.0.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.7.tgz",
+      "integrity": "sha512-/GVLhB5zaxYGIaC4GFfsfk81SDq9ht0HbEHhHB+t1SqNPV8gnULDV2ZE0Cg+LGj+3YnPtSwpb7tS0vaHUcihVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.6",
-        "@angular-devkit/schematics": "22.0.6",
+        "@angular-devkit/core": "22.0.7",
+        "@angular-devkit/schematics": "22.0.7",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -4666,17 +4596,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4689,22 +4619,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4720,14 +4650,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4742,14 +4672,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4760,9 +4690,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4777,15 +4707,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4802,9 +4732,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4816,16 +4746,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4844,16 +4774,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4868,13 +4798,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5824,9 +5754,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
+      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5940,9 +5870,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -5960,9 +5890,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
         "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
@@ -6107,9 +6037,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001805",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -6861,9 +6791,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.391",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.391.tgz",
-      "integrity": "sha512-YmCu4856jkgKT1Nh6fwRdeVrM6Ydf/fBnq51tpmSfX+jOcUMTxh31yH6hjKScRenhB2oDSvA9oooxcpjogPeig==",
+      "version": "1.5.395",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
+      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7879,12 +7809,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -7973,9 +7904,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -8501,9 +8432,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.1.tgz",
-      "integrity": "sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8656,9 +8587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9565,9 +9496,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9802,14 +9733,13 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
-      "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.0.tgz",
+      "integrity": "sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "listr2": "^10.2.1",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.5",
         "string-argv": "^0.3.2",
         "tinyexec": "^1.2.4"
       },
@@ -9824,6 +9754,19 @@
       },
       "optionalDependencies": {
         "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/listr2": {
@@ -11814,9 +11757,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -11929,13 +11872,14 @@
       "optional": true
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -11979,9 +11923,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12295,9 +12239,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
       "dev": true,
       "funding": [
         {
@@ -12315,7 +12259,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12423,9 +12367,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -13639,9 +13583,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "17.14.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.0.tgz",
-      "integrity": "sha512-8xkHPpdqYryeIsOgfsYTmr6cIeC4nLYWk5S8BPxpodq8mIuepggkMljsHewWfuAjj/+qpRKou2QerhjMH3iasg==",
+      "version": "17.14.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
+      "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
       "dev": true,
       "funding": [
         {
@@ -13657,7 +13601,7 @@
       "dependencies": {
         "@csstools/css-calc": "^3.2.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.5",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
         "@csstools/css-tokenizer": "^4.0.0",
         "@csstools/media-query-list-parser": "^5.0.0",
         "@csstools/selector-resolve-nested": "^4.0.0",
@@ -13669,9 +13613,9 @@
         "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^11.1.3",
+        "file-entry-cache": "^11.1.5",
         "global-modules": "^2.0.0",
-        "globby": "^16.2.0",
+        "globby": "^16.2.1",
         "globjoin": "^0.1.4",
         "html-tags": "^5.1.0",
         "ignore": "^7.0.5",
@@ -13681,12 +13625,12 @@
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.16",
         "postcss-safe-parser": "^7.0.1",
         "postcss-selector-parser": "^7.1.4",
         "postcss-value-parser": "^4.2.0",
         "string-width": "^8.2.1",
-        "supports-hyperlinks": "^4.4.0",
+        "supports-hyperlinks": "^4.5.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",
         "write-file-atomic": "^7.0.1"
@@ -14048,9 +13992,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14119,22 +14063,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
-      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.8"
+        "tldts-core": "^7.4.9"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
-      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -14420,16 +14364,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
-      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.64.0",
-        "@typescript-eslint/parser": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.0.5.tgz",
-      "integrity": "sha512-qy1scYkkhedGxrU2GjOUoh76xjsxCDOODWdVfg4aXLXG7RBIH6hOuKdcNpR/sWhfSdY02a11QYRN2CqoqWDvZQ==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-22.0.6.tgz",
+      "integrity": "sha512-b36f4b+7yQpuulG9Ai2O38SV2tsqyNeYTYCH9TehMir18XlTx+NtLELwA8Sfi24tHByJHEDADQZtHPWWUj71/w==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.0.7.tgz",
-      "integrity": "sha512-iun8auXVnpPzunhtaPHMF0gSpByxv7kHhG3Nb6r34eJITW5p06LYyZbkAnl5ERArmgQvEV4pTjoo7ZTK3cJzzw==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.0.8.tgz",
+      "integrity": "sha512-FnwkXndUgAyWk1/p5flMfocIUtuuneJ01mxC1FxRc5/bdWTyNVeQDsM9Lw4PEAPc0AHu//EnblegRq8o6LGdUQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -631,14 +631,14 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "22.0.7",
+        "@angular/core": "22.0.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.0.7.tgz",
-      "integrity": "sha512-zhFPKYJzpml5bt58DkJq8S6S2bSJBomebgLYtUvZNLdQMicd5qmRGX6I3LO7Jd+HgjB2Flne/sloI+Jcyz1aOQ==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.0.8.tgz",
+      "integrity": "sha512-ot7rvntfkZsPHmp8yl6PWUj/yG4e50X0+YeR7QYy/rEYKBiIg91w8GwjxSzaF4g5+bzJGDv7l/XnachKm0IySg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.0.7.tgz",
-      "integrity": "sha512-/3HjBJUzljyPgb77R679+FN1+27xIGuLCAhuqzfj6DxX5WJOOmQOWE/k12eAZujE+ZypSf8ZGkfaukZV43FwoA==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.0.8.tgz",
+      "integrity": "sha512-shBqaUxMtqriv4UG2MHmYT8GSvDizI40mUFkOfeQ1yRJ2C9dk0TnWKPwjSO7o6bs6UiU6V8Y3uSWdmfCGVVZAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -671,7 +671,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.0.7",
+        "@angular/compiler": "22.0.8",
         "typescript": ">=6.0 <6.1"
       },
       "peerDependenciesMeta": {
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.0.7.tgz",
-      "integrity": "sha512-A5xKJx5wuuZfeJhShyZvbgicYtT3Jpw/5wJd1cfrcKU+i63CagRIg9jSktTW/e+2hxG1tIQrfKQUGeclmsAUUA==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.0.8.tgz",
+      "integrity": "sha512-HagZZVzbtXd+ZhMb++k/HOtr/UTiBROHHH7xutgYgnSnPRXX0kCca5EQ02OZ/OCWfsMP5liSJDfwiePFULKA6Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -692,7 +692,7 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "22.0.7",
+        "@angular/compiler": "22.0.8",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -706,9 +706,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.0.7.tgz",
-      "integrity": "sha512-24ldrCORVCi3SoqtshjD8PcT5zg4aIXy9p8+GsO/c3yuhAouVOwL4z1/btNdo7UZv1asyaT3w4lgzprN8TGpjA==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.0.8.tgz",
+      "integrity": "sha512-KlLJE8rgziSBqCQy+cqCHPEQPGjJEY53i1vZbpnBoLXhnwswLJ3O0c76RHNpIrlrvr9v4p3b2/LxSE8wQmdStg==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -719,22 +719,22 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.0.7",
-        "@angular/core": "22.0.7",
-        "@angular/platform-browser": "22.0.7",
+        "@angular/common": "22.0.8",
+        "@angular/core": "22.0.8",
+        "@angular/platform-browser": "22.0.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.0.5.tgz",
-      "integrity": "sha512-A0SnDMvWQBxv3dB2w33GXwuo1/puKtFe8ZMQmIiurS5bbTQpV7UHAM0pWzg7L4DG2cvaH4WZGRPfNG3f8fh+yA==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-22.0.6.tgz",
+      "integrity": "sha512-EVKhP3689o+7J4TD7KMzmypxKGAUdvU3UsIhXYEoJ2IyxF/jAfuWSVKBmR8Ig6w74wSayBglfOTVoI3RuDL9NA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "22.0.5",
+        "@angular/cdk": "22.0.6",
         "@angular/common": "^22.0.0 || ^23.0.0",
         "@angular/core": "^22.0.0 || ^23.0.0",
         "@angular/forms": "^22.0.0 || ^23.0.0",
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.0.7.tgz",
-      "integrity": "sha512-iCuREIWRnDCsd7mI5vn5ovXjcSwseWR4qfd+zo6QUrY2O9zkUNV79YuCqVjSzvWyvU2rtR5iRBvpB5JQgBELeg==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.0.8.tgz",
+      "integrity": "sha512-FllGHCayu5Dv82HAA9ORL04Xf+In9JGMbQ1Vn4QnhrAVxBz182vm+ZwszLzRDSAwmfeIjZDeK49tKAcqHR9XNg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -754,9 +754,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "22.0.7",
-        "@angular/common": "22.0.7",
-        "@angular/core": "22.0.7"
+        "@angular/animations": "22.0.8",
+        "@angular/common": "22.0.8",
+        "@angular/core": "22.0.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.0.7.tgz",
-      "integrity": "sha512-uMh+2S5y5Z6hTeFL85tDehfqAwVYjnTlHxpCrW+75RD4Z+rLl0/ff2ag3bXknzNyg0Q9LPOH6t/eCcQYajNOQQ==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.0.8.tgz",
+      "integrity": "sha512-9NO5K03QqfWMWWZ+Uu4WqBSLw/YAot918cBUFdgl6mTUOfoHi/xWO5pAt0SEpbXMHmWafJBdb99GRlAGybGSTg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -776,9 +776,9 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "22.0.7",
-        "@angular/core": "22.0.7",
-        "@angular/platform-browser": "22.0.7",
+        "@angular/common": "22.0.8",
+        "@angular/core": "22.0.8",
+        "@angular/platform-browser": "22.0.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -1231,9 +1231,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "dev": true,
       "funding": [
         {
@@ -1255,9 +1255,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
-      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
       "dev": true,
       "funding": [
         {
@@ -1272,7 +1272,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.1.0",
-        "@csstools/css-calc": "^3.2.1"
+        "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -1306,9 +1306,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
-      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
       "dev": true,
       "funding": [
         {
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5754,9 +5754,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
-      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
+      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8062,9 +8062,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -9733,9 +9733,9 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.0.tgz",
-      "integrity": "sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.1.tgz",
+      "integrity": "sha512-FnHWpSe5cPRtrDG+soOuNdBxb4XQb2gN5EqpEWKdweyqyOfpl4QSjbrz3ilcIf0WXmkiNQGZZRQ23R5YtB3TEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12239,9 +12239,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:playwright": "eslint -c ./tests/eslint.config.js ./tests",
     "lint:scripts": "eslint -c ./scripts/eslint.config.js ./scripts",
     "lint:style": "stylelint 'src/**/*.scss'",
+    "lint-staged": "lint-staged",
     "ng": "ng",
     "playwright:install": "playwright install --with-deps",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
   },
   "packageManager": "npm@11.17.0",
   "allowScripts": {
-    "@parcel/watcher@2.5.6": true,
     "esbuild@0.28.1": true,
     "esbuild@0.27.7": true,
     "fsevents@2.3.2": true,
@@ -115,6 +114,7 @@
     "iframe-resizer@4.4.5": true,
     "lmdb@3.5.4": true,
     "msgpackr-extract@3.0.4": true,
-    "unrs-resolver@1.12.2": true
+    "unrs-resolver@1.12.2": true,
+    "@parcel/watcher@2.6.0": true
   }
 }

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -33,7 +33,21 @@
     @for (column of columnsToDisplay(); track column) {
       <ng-container matColumnDef="{{ column }}">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column }}</th>
-        <td mat-cell *matCellDef="let element">{{ element[column] }}</td>
+        @if (column === 'source') {
+          <td mat-cell *matCellDef="let element">
+            <a [href]="element[column]" target="_blank" rel="noopener noreferrer">
+              {{ element[column] }}
+            </a>
+          </td>
+        } @else if (column === 'image') {
+          <td mat-cell *matCellDef="let element">
+            <img [src]="element[column].url" [alt]="element[column].title" width="50" height="50" />
+          </td>
+        } @else {
+          <td mat-cell *matCellDef="let element">
+            {{ element[column] }}
+          </td>
+        }
         @if (column === 'name') {
           <td mat-footer-cell *matFooterCellDef class="bg-primary">Total # of elements:</td>
         } @else if (column === 'atomic_mass') {

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -28,11 +28,27 @@
   </ng-template>
 </div>
 <div class="overflow-auto">
-  <table mat-table [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z8" matSort>
+  <table
+    mat-table
+    [dataSource]="dataSource"
+    multiTemplateDataRows
+    class="mat-elevation-z8 resizable-table"
+    [style.width.px]="tableWidth()"
+    matSort
+  >
     <!-- Columns Definitions -->
     @for (column of columnsToDisplay(); track column) {
       <ng-container matColumnDef="{{ column }}">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column }}</th>
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          [appColumnResize]="column"
+          [style.width.px]="columnWidth(column)"
+          (widthChange)="setColumnWidth(column, $event)"
+        >
+          {{ column }}
+        </th>
         @if (column === 'source') {
           <td mat-cell *matCellDef="let element">
             <a [href]="element[column]" target="_blank" rel="noopener noreferrer">
@@ -60,7 +76,12 @@
 
     <!-- Expand Column Definition -->
     <ng-container matColumnDef="expand">
-      <th mat-header-cell *matHeaderCellDef aria-label="row actions"></th>
+      <th
+        mat-header-cell
+        *matHeaderCellDef
+        aria-label="row actions"
+        [style.width.px]="expandColumnWidth"
+      ></th>
       <td mat-cell *matCellDef="let element">
         <button mat-icon-button aria-label="expand row" (click)="toggleExpanded($event, element)">
           @if (isExpanded(element)) {

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -94,9 +94,17 @@
       <td mat-footer-cell *matFooterCellDef class="bg-primary"></td>
     </ng-container>
 
+    <!-- Spacer Column Definition - flexible column that absorbs slack so resizable
+         columns keep their exact widths under the fixed table layout -->
+    <ng-container [matColumnDef]="resizeSpacerColumn">
+      <th mat-header-cell *matHeaderCellDef aria-hidden="true" class="resize-spacer-cell"></th>
+      <td mat-cell *matCellDef="let element" aria-hidden="true" class="resize-spacer-cell"></td>
+      <td mat-footer-cell *matFooterCellDef class="bg-primary resize-spacer-cell"></td>
+    </ng-container>
+
     <!-- Expanded Content Column - The detail row is made up of this one column that spans across all columns -->
     <ng-container matColumnDef="expandedDetail">
-      <td mat-cell *matCellDef="let element" [attr.colspan]="columnsToDisplayWithExpand().length">
+      <td mat-cell *matCellDef="let element" [attr.colspan]="columnsToRender().length">
         <div
           class="example-element-detail-wrapper"
           [class.example-element-detail-wrapper-expanded]="isExpanded(element)"
@@ -107,17 +115,17 @@
     </ng-container>
 
     <!-- Row Definitions -->
-    <tr mat-header-row *matHeaderRowDef="columnsToDisplayWithExpand(); sticky: true"></tr>
+    <tr mat-header-row *matHeaderRowDef="columnsToRender(); sticky: true"></tr>
     <tr
       mat-row
-      *matRowDef="let element; columns: columnsToDisplayWithExpand()"
+      *matRowDef="let element; columns: columnsToRender()"
       class="example-element-row"
       [class.example-expanded-row]="isExpanded(element)"
       (click)="toggleExpanded($event, element)"
       (keydown)="toggleExpanded($event, element)"
     ></tr>
     <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="example-detail-row"></tr>
-    <tr mat-footer-row *matFooterRowDef="columnsToDisplayWithExpand(); sticky: true"></tr>
+    <tr mat-footer-row *matFooterRowDef="columnsToRender(); sticky: true"></tr>
   </table>
 </div>
 <mat-paginator

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -57,7 +57,9 @@
           </td>
         } @else if (column === 'image') {
           <td mat-cell *matCellDef="let element">
-            <img [src]="element[column].url" [alt]="element[column].title" width="50" height="50" />
+            <span class="image-thumb">
+              <img [ngSrc]="element[column].url" [alt]="element[column].title" fill />
+            </span>
           </td>
         } @else {
           <td mat-cell *matCellDef="let element">

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -101,7 +101,12 @@
     <ng-container [matColumnDef]="resizeSpacerColumn">
       <th mat-header-cell *matHeaderCellDef aria-hidden="true" class="resize-spacer-cell"></th>
       <td mat-cell *matCellDef="let element" aria-hidden="true" class="resize-spacer-cell"></td>
-      <td mat-footer-cell *matFooterCellDef class="bg-primary resize-spacer-cell"></td>
+      <td
+        mat-footer-cell
+        *matFooterCellDef
+        aria-hidden="true"
+        class="bg-primary resize-spacer-cell"
+      ></td>
     </ng-container>
 
     <!-- Expanded Content Column - The detail row is made up of this one column that spans across all columns -->

--- a/src/app/components/mat-table/mat-table.scss
+++ b/src/app/components/mat-table/mat-table.scss
@@ -11,6 +11,7 @@ table {
 
 .resizable-table {
   table-layout: fixed;
+  min-width: 100%;
 }
 
 .resizable-table th,
@@ -22,36 +23,6 @@ table {
 
 .resizable-table th.mat-mdc-header-cell {
   position: relative;
-}
-
-.column-resize-handle {
-  position: absolute;
-  inset-block: 0;
-  inset-inline-end: 0;
-  width: 8px;
-  cursor: col-resize;
-  touch-action: none;
-  user-select: none;
-  z-index: 1;
-}
-
-.column-resize-handle::after {
-  content: '';
-  position: absolute;
-  inset-block: 25%;
-  inset-inline-end: 3px;
-  width: 2px;
-  background: rgb(0 0 0 / 24%);
-}
-
-.column-resize-handle:hover::after,
-.column-resize-handle:focus-visible::after {
-  background: var(--mat-sys-primary, #3f51b5);
-}
-
-.column-resize-handle:focus-visible {
-  outline: 2px solid var(--mat-sys-primary, #3f51b5);
-  outline-offset: -2px;
 }
 
 tr.example-detail-row {

--- a/src/app/components/mat-table/mat-table.scss
+++ b/src/app/components/mat-table/mat-table.scss
@@ -30,6 +30,17 @@ table {
   overflow: hidden;
 }
 
+.image-thumb {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 50px;
+}
+
+.image-thumb img {
+  object-fit: cover;
+}
+
 tr.example-detail-row {
   height: 0;
 }

--- a/src/app/components/mat-table/mat-table.scss
+++ b/src/app/components/mat-table/mat-table.scss
@@ -25,6 +25,11 @@ table {
   position: relative;
 }
 
+.resizable-table .resize-spacer-cell {
+  padding: 0;
+  overflow: hidden;
+}
+
 tr.example-detail-row {
   height: 0;
 }

--- a/src/app/components/mat-table/mat-table.scss
+++ b/src/app/components/mat-table/mat-table.scss
@@ -9,6 +9,51 @@ table {
   width: 100%;
 }
 
+.resizable-table {
+  table-layout: fixed;
+}
+
+.resizable-table th,
+.resizable-table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resizable-table th.mat-mdc-header-cell {
+  position: relative;
+}
+
+.column-resize-handle {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  width: 8px;
+  cursor: col-resize;
+  touch-action: none;
+  user-select: none;
+  z-index: 1;
+}
+
+.column-resize-handle::after {
+  content: '';
+  position: absolute;
+  inset-block: 25%;
+  inset-inline-end: 3px;
+  width: 2px;
+  background: rgb(0 0 0 / 24%);
+}
+
+.column-resize-handle:hover::after,
+.column-resize-handle:focus-visible::after {
+  background: var(--mat-sys-primary, #3f51b5);
+}
+
+.column-resize-handle:focus-visible {
+  outline: 2px solid var(--mat-sys-primary, #3f51b5);
+  outline-offset: -2px;
+}
+
 tr.example-detail-row {
   height: 0;
 }

--- a/src/app/components/mat-table/mat-table.scss
+++ b/src/app/components/mat-table/mat-table.scss
@@ -56,6 +56,6 @@ tr.example-element-row:not(.example-expanded-row):active {
 .column-chooser-container {
   display: flex;
   justify-content: flex-end;
-  padding: 0.25rem 0;
+  padding: 0.25rem 1rem;
   align-items: center;
 }

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -10,6 +10,7 @@ import {
   EXPAND_COLUMN_WIDTH,
   FULL_LIST_OF_COLUMNS,
   MatTable,
+  RESIZE_SPACER_COLUMN,
 } from './mat-table';
 
 describe('MatTable', () => {
@@ -45,6 +46,14 @@ describe('MatTable', () => {
 
     it('creates columnsToDisplayWithExpand by appending expand column', () => {
       expect(component.columnsToDisplayWithExpand()).toEqual([...DEFAULT_COLUMNS, 'expand']);
+    });
+
+    it('creates columnsToRender by appending the expand and spacer columns', () => {
+      expect(component.columnsToRender()).toEqual([
+        ...DEFAULT_COLUMNS,
+        'expand',
+        RESIZE_SPACER_COLUMN,
+      ]);
     });
 
     it('exposes fullListOfColumns constant', () => {
@@ -144,6 +153,16 @@ describe('MatTable', () => {
 
     it('exposes the expand column width constant', () => {
       expect(component.expandColumnWidth).toBe(EXPAND_COLUMN_WIDTH);
+    });
+
+    it('renders a trailing spacer column after the expand column', () => {
+      expect(component.resizeSpacerColumn).toBe(RESIZE_SPACER_COLUMN);
+      expect(component.columnsToRender().at(-1)).toBe(RESIZE_SPACER_COLUMN);
+    });
+
+    it('keeps the spacer column present even with no displayed columns', () => {
+      component.columnsToDisplay.set([]);
+      expect(component.columnsToRender()).toEqual(['expand', RESIZE_SPACER_COLUMN]);
     });
   });
 
@@ -397,9 +416,9 @@ describe('MatTable', () => {
   });
 
   describe('Template Integration - Table Headers and Footers', () => {
-    it('renders table header for each column in columnsToDisplayWithExpand', () => {
+    it('renders table header for each column in columnsToRender', () => {
       const headers = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
-      expect(headers.length).toBe(component.columnsToDisplayWithExpand().length);
+      expect(headers.length).toBe(component.columnsToRender().length);
     });
 
     it('renders table footer with total element count', () => {
@@ -598,7 +617,7 @@ describe('MatTable', () => {
 
       const updatedHeaders = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
       expect(updatedHeaders.length).not.toBe(initialCount);
-      expect(updatedHeaders.length).toBe(3); // name, symbol, expand
+      expect(updatedHeaders.length).toBe(4); // name, symbol, expand, spacer
     });
 
     it('expandedDetail row maintains proper colspan after column change', () => {
@@ -612,7 +631,7 @@ describe('MatTable', () => {
       const colspan = (detailRow?.nativeElement as HTMLElement).parentElement?.getAttribute(
         'colspan',
       );
-      expect(colspan).toBe(component.columnsToDisplayWithExpand().length.toString());
+      expect(colspan).toBe(component.columnsToRender().length.toString());
     });
   });
 

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -4,7 +4,13 @@ import { By } from '@angular/platform-browser';
 import { vi } from 'vitest';
 import { FilterState } from '../../interfaces/filter-state';
 import { ColumnSelect } from './column-select/column-select';
-import { DEFAULT_COLUMNS, FULL_LIST_OF_COLUMNS, MatTable } from './mat-table';
+import {
+  DEFAULT_COLUMNS,
+  DEFAULT_COLUMN_WIDTH,
+  EXPAND_COLUMN_WIDTH,
+  FULL_LIST_OF_COLUMNS,
+  MatTable,
+} from './mat-table';
 
 describe('MatTable', () => {
   let component: MatTable;
@@ -99,6 +105,45 @@ describe('MatTable', () => {
 
       component.columnsToDisplay.set(DEFAULT_COLUMNS);
       expect(component.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
+    });
+  });
+
+  describe('Column Resizing', () => {
+    it('returns the default width for columns without an override', () => {
+      expect(component.columnWidth('name')).toBe(DEFAULT_COLUMN_WIDTH);
+    });
+
+    it('stores and returns an explicit width for a column', () => {
+      component.setColumnWidth('name', 240);
+      expect(component.columnWidth('name')).toBe(240);
+    });
+
+    it('preserves widths of other columns when one is resized', () => {
+      component.setColumnWidth('name', 240);
+      component.setColumnWidth('symbol', 90);
+
+      expect(component.columnWidth('name')).toBe(240);
+      expect(component.columnWidth('symbol')).toBe(90);
+    });
+
+    it('computes tableWidth from default widths plus the expand column', () => {
+      const expected = DEFAULT_COLUMNS.length * DEFAULT_COLUMN_WIDTH + EXPAND_COLUMN_WIDTH;
+      expect(component.tableWidth()).toBe(expected);
+    });
+
+    it('reflects a resized column in tableWidth', () => {
+      const before = component.tableWidth();
+      component.setColumnWidth('name', DEFAULT_COLUMN_WIDTH + 100);
+      expect(component.tableWidth()).toBe(before + 100);
+    });
+
+    it('recomputes tableWidth when displayed columns change', () => {
+      component.columnsToDisplay.set(['name', 'symbol']);
+      expect(component.tableWidth()).toBe(2 * DEFAULT_COLUMN_WIDTH + EXPAND_COLUMN_WIDTH);
+    });
+
+    it('exposes the expand column width constant', () => {
+      expect(component.expandColumnWidth).toBe(EXPAND_COLUMN_WIDTH);
     });
   });
 

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -164,6 +164,14 @@ describe('MatTable', () => {
       component.columnsToDisplay.set([]);
       expect(component.columnsToRender()).toEqual(['expand', RESIZE_SPACER_COLUMN]);
     });
+
+    it('hides all spacer cells from the accessibility tree', () => {
+      const host = fixture.nativeElement as HTMLElement;
+      const spacerCells = Array.from(host.querySelectorAll('.resize-spacer-cell'));
+
+      expect(spacerCells.length).toBeGreaterThan(0);
+      expect(spacerCells.every((cell) => cell.getAttribute('aria-hidden') === 'true')).toBe(true);
+    });
   });
 
   describe('Filtering', () => {

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -64,6 +64,7 @@ export const DEFAULT_COLUMNS = [
 
 export const DEFAULT_COLUMN_WIDTH = 150;
 export const EXPAND_COLUMN_WIDTH = 56;
+export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
 
 @Component({
   selector: 'app-mat-table',
@@ -93,6 +94,14 @@ export class MatTable {
   readonly dataSource = new MatTableDataSource(ELEMENT_DATA.elements);
   readonly columnsToDisplay = signal<string[]>(DEFAULT_COLUMNS);
   readonly columnsToDisplayWithExpand = computed(() => [...this.columnsToDisplay(), 'expand']);
+  // A trailing flexible spacer column absorbs any slack so the resizable columns
+  // always render at their exact specified widths (never proportionally redistributed
+  // by the fixed table layout), which keeps drag resizing stable when the table has
+  // fewer columns than fill the viewport.
+  readonly columnsToRender = computed(() => [
+    ...this.columnsToDisplayWithExpand(),
+    RESIZE_SPACER_COLUMN,
+  ]);
   readonly tableWidth = computed(() => {
     const widths = this.columnWidths();
     const dataTotal = this.columnsToDisplay().reduce(
@@ -102,6 +111,7 @@ export class MatTable {
 
     return dataTotal + EXPAND_COLUMN_WIDTH;
   });
+  readonly resizeSpacerColumn = RESIZE_SPACER_COLUMN;
   readonly fullListOfColumns = FULL_LIST_OF_COLUMNS;
   readonly defaultColumns = DEFAULT_COLUMNS;
   readonly expandedElement = signal<PeriodicElement | null>(null);

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -1,4 +1,5 @@
 import { OverlayModule } from '@angular/cdk/overlay';
+import { NgOptimizedImage } from '@angular/common';
 import { Component, computed, effect, signal, viewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -77,6 +78,7 @@ export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
     MatPaginatorModule,
     MatTableModule,
     MatSortModule,
+    NgOptimizedImage,
     OverlayModule,
     PeriodicElementDetail,
   ],

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { ColumnResize } from '../../directives/column-resize';
 import { ELEMENT_DATA } from '../../interfaces/data';
 import { FilterState } from '../../interfaces/filter-state';
 import { PeriodicElement } from '../../interfaces/periodic-element';
@@ -61,9 +62,13 @@ export const DEFAULT_COLUMNS = [
   'block',
 ];
 
+export const DEFAULT_COLUMN_WIDTH = 150;
+export const EXPAND_COLUMN_WIDTH = 56;
+
 @Component({
   selector: 'app-mat-table',
   imports: [
+    ColumnResize,
     ColumnSelect,
     Filter,
     MatButtonModule,
@@ -88,10 +93,21 @@ export class MatTable {
   readonly dataSource = new MatTableDataSource(ELEMENT_DATA.elements);
   readonly columnsToDisplay = signal<string[]>(DEFAULT_COLUMNS);
   readonly columnsToDisplayWithExpand = computed(() => [...this.columnsToDisplay(), 'expand']);
+  readonly tableWidth = computed(() => {
+    const widths = this.columnWidths();
+    const dataTotal = this.columnsToDisplay().reduce(
+      (total, column) => total + (widths[column] ?? DEFAULT_COLUMN_WIDTH),
+      0,
+    );
+
+    return dataTotal + EXPAND_COLUMN_WIDTH;
+  });
   readonly fullListOfColumns = FULL_LIST_OF_COLUMNS;
   readonly defaultColumns = DEFAULT_COLUMNS;
   readonly expandedElement = signal<PeriodicElement | null>(null);
   readonly isOpen = signal(false);
+  readonly columnWidths = signal<Record<string, number>>({});
+  readonly expandColumnWidth = EXPAND_COLUMN_WIDTH;
 
   constructor() {
     this.dataSource.filterPredicate = (data: PeriodicElement, filter: string) => {
@@ -145,6 +161,14 @@ export class MatTable {
 
   isExpanded(element: PeriodicElement) {
     return this.expandedElement() === element;
+  }
+
+  columnWidth(column: string): number {
+    return this.columnWidths()[column] ?? DEFAULT_COLUMN_WIDTH;
+  }
+
+  setColumnWidth(column: string, width: number): void {
+    this.columnWidths.update((widths) => ({ ...widths, [column]: width }));
   }
 
   private getCachedFilterState(filter: string): FilterState {

--- a/src/app/directives/column-resize.spec.ts
+++ b/src/app/directives/column-resize.spec.ts
@@ -249,11 +249,13 @@ describe('ColumnResize', () => {
     expect(parentClick).not.toHaveBeenCalled();
   });
 
-  it('sets the aria-label from the column at initialization', () => {
+  it('updates the aria-label when the column input changes at runtime', () => {
+    expect(handle.getAttribute('aria-label')).toBe('Resize name column');
+
     host.column.set('symbol');
     fixture.detectChanges();
 
-    expect(handle.getAttribute('aria-label')).toBe('Resize name column');
+    expect(handle.getAttribute('aria-label')).toBe('Resize symbol column');
   });
 
   it('removes handle listeners on destroy', () => {
@@ -263,5 +265,23 @@ describe('ColumnResize', () => {
     handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
 
     expect(host.widths).toHaveLength(0);
+  });
+});
+
+@Component({
+  selector: 'app-sticky-host',
+  imports: [ColumnResize],
+  template: `<th appColumnResize="name" style="position: sticky">Header</th>`,
+})
+class StickyHostComponent {}
+
+describe('ColumnResize with a pre-positioned host', () => {
+  it('does not override an existing position such as sticky', () => {
+    TestBed.configureTestingModule({ imports: [StickyHostComponent] });
+    const fixture = TestBed.createComponent(StickyHostComponent);
+    fixture.detectChanges();
+
+    const th = fixture.debugElement.query(By.css('th')).nativeElement as HTMLElement;
+    expect(th.style.position).toBe('sticky');
   });
 });

--- a/src/app/directives/column-resize.spec.ts
+++ b/src/app/directives/column-resize.spec.ts
@@ -58,6 +58,11 @@ describe('ColumnResize', () => {
     expect(th.style.position).toBe('relative');
   });
 
+  it('initializes required separator value attributes on the handle', () => {
+    expect(handle.getAttribute('aria-valuenow')).not.toBeNull();
+    expect(handle.getAttribute('aria-valuemin')).toBe('60');
+  });
+
   it('widens the column and emits width on ArrowRight', () => {
     setOffsetWidth(th, 200);
 

--- a/src/app/directives/column-resize.spec.ts
+++ b/src/app/directives/column-resize.spec.ts
@@ -66,6 +66,35 @@ describe('ColumnResize', () => {
     expect(handle.getAttribute('aria-valuemax')).toBe('1000');
   });
 
+  it('keeps aria-valuemin/aria-valuemax in sync when inputs change at runtime', () => {
+    host.minWidth.set(80);
+    host.maxWidth.set(500);
+    fixture.detectChanges();
+
+    expect(handle.getAttribute('aria-valuemin')).toBe('80');
+    expect(handle.getAttribute('aria-valuemax')).toBe('500');
+  });
+
+  it('re-clamps an already-resized column when maxWidth shrinks below it', () => {
+    setOffsetWidth(th, 200);
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(host.widths.at(-1)).toBe(216);
+
+    host.maxWidth.set(180);
+    fixture.detectChanges();
+
+    expect(host.widths.at(-1)).toBe(180);
+    expect(handle.getAttribute('aria-valuenow')).toBe('180');
+    expect(handle.getAttribute('aria-valuemax')).toBe('180');
+  });
+
+  it('does not emit on input change when the column has not been resized', () => {
+    host.maxWidth.set(400);
+    fixture.detectChanges();
+
+    expect(host.widths).toHaveLength(0);
+  });
+
   it('widens the column and emits width on ArrowRight', () => {
     setOffsetWidth(th, 200);
 
@@ -117,6 +146,22 @@ describe('ColumnResize', () => {
     document.dispatchEvent(new MouseEvent('pointermove', { clientX: 380, bubbles: true }));
 
     expect(host.widths.at(-1)).toBe(230);
+  });
+
+  it('ignores non-primary pointer buttons so secondary clicks behave normally', () => {
+    setOffsetWidth(th, 150);
+
+    const event = new MouseEvent('pointerdown', {
+      clientX: 300,
+      button: 2,
+      bubbles: true,
+      cancelable: true,
+    });
+    handle.dispatchEvent(event);
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 380, bubbles: true }));
+
+    expect(host.widths).toHaveLength(0);
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it('clamps drag resizing to the minimum width', () => {

--- a/src/app/directives/column-resize.spec.ts
+++ b/src/app/directives/column-resize.spec.ts
@@ -10,6 +10,7 @@ import { ColumnResize } from './column-resize';
   template: `<th
     [appColumnResize]="column()"
     [minWidth]="minWidth()"
+    [maxWidth]="maxWidth()"
     (widthChange)="onWidth($event)"
   >
     Header
@@ -18,6 +19,7 @@ import { ColumnResize } from './column-resize';
 class HostComponent {
   readonly column = signal('name');
   readonly minWidth = signal(60);
+  readonly maxWidth = signal(1000);
   readonly widths: number[] = [];
 
   onWidth(width: number): void {
@@ -61,6 +63,7 @@ describe('ColumnResize', () => {
   it('initializes required separator value attributes on the handle', () => {
     expect(handle.getAttribute('aria-valuenow')).not.toBeNull();
     expect(handle.getAttribute('aria-valuemin')).toBe('60');
+    expect(handle.getAttribute('aria-valuemax')).toBe('1000');
   });
 
   it('widens the column and emits width on ArrowRight', () => {
@@ -88,6 +91,17 @@ describe('ColumnResize', () => {
     expect(host.widths.at(-1)).toBe(60);
   });
 
+  it('clamps keyboard resizing to the maximum width', () => {
+    host.maxWidth.set(210);
+    fixture.detectChanges();
+    setOffsetWidth(th, 200);
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    expect(host.widths.at(-1)).toBe(210);
+    expect(handle.getAttribute('aria-valuenow')).toBe('210');
+  });
+
   it('ignores non-arrow keys', () => {
     setOffsetWidth(th, 200);
 
@@ -112,6 +126,17 @@ describe('ColumnResize', () => {
     document.dispatchEvent(new MouseEvent('pointermove', { clientX: 0, bubbles: true }));
 
     expect(host.widths.at(-1)).toBe(60);
+  });
+
+  it('clamps drag resizing to the maximum width', () => {
+    host.maxWidth.set(400);
+    fixture.detectChanges();
+    setOffsetWidth(th, 150);
+
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 900, bubbles: true }));
+
+    expect(host.widths.at(-1)).toBe(400);
   });
 
   it('stops tracking pointer movement after release', () => {

--- a/src/app/directives/column-resize.spec.ts
+++ b/src/app/directives/column-resize.spec.ts
@@ -1,0 +1,148 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { vi } from 'vitest';
+import { ColumnResize } from './column-resize';
+
+@Component({
+  selector: 'app-host',
+  imports: [ColumnResize],
+  template: `<th
+    [appColumnResize]="column()"
+    [minWidth]="minWidth()"
+    (widthChange)="onWidth($event)"
+  >
+    Header
+  </th>`,
+})
+class HostComponent {
+  readonly column = signal('name');
+  readonly minWidth = signal(60);
+  readonly widths: number[] = [];
+
+  onWidth(width: number): void {
+    this.widths.push(width);
+  }
+}
+
+function setOffsetWidth(element: HTMLElement, value: number): void {
+  Object.defineProperty(element, 'offsetWidth', { configurable: true, value });
+}
+
+describe('ColumnResize', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+  let th: HTMLElement;
+  let handle: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    th = fixture.debugElement.query(By.css('th')).nativeElement as HTMLElement;
+    handle = fixture.debugElement.query(By.css('.column-resize-handle'))
+      .nativeElement as HTMLElement;
+  });
+
+  it('creates an accessible resize handle inside the host cell', () => {
+    expect(handle).toBeTruthy();
+    expect(handle.getAttribute('role')).toBe('separator');
+    expect(handle.getAttribute('aria-orientation')).toBe('vertical');
+    expect(handle.getAttribute('aria-label')).toBe('Resize name column');
+    expect(handle.getAttribute('tabindex')).toBe('0');
+    expect(th.style.position).toBe('relative');
+  });
+
+  it('widens the column and emits width on ArrowRight', () => {
+    setOffsetWidth(th, 200);
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    expect(host.widths.at(-1)).toBe(216);
+    expect(handle.getAttribute('aria-valuenow')).toBe('216');
+  });
+
+  it('narrows the column and emits width on ArrowLeft', () => {
+    setOffsetWidth(th, 200);
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+
+    expect(host.widths.at(-1)).toBe(184);
+  });
+
+  it('clamps keyboard resizing to the minimum width', () => {
+    setOffsetWidth(th, 64);
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+
+    expect(host.widths.at(-1)).toBe(60);
+  });
+
+  it('ignores non-arrow keys', () => {
+    setOffsetWidth(th, 200);
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(host.widths).toHaveLength(0);
+  });
+
+  it('emits a new width while dragging the handle', () => {
+    setOffsetWidth(th, 150);
+
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 380, bubbles: true }));
+
+    expect(host.widths.at(-1)).toBe(230);
+  });
+
+  it('clamps drag resizing to the minimum width', () => {
+    setOffsetWidth(th, 150);
+
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 0, bubbles: true }));
+
+    expect(host.widths.at(-1)).toBe(60);
+  });
+
+  it('stops tracking pointer movement after release', () => {
+    setOffsetWidth(th, 150);
+
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    const emitCount = host.widths.length;
+
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 500, bubbles: true }));
+
+    expect(host.widths).toHaveLength(emitCount);
+  });
+
+  it('does not let handle clicks bubble to the header (avoids sorting)', () => {
+    const parentClick = vi.fn();
+    th.addEventListener('click', parentClick);
+
+    handle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('sets the aria-label from the column at initialization', () => {
+    host.column.set('symbol');
+    fixture.detectChanges();
+
+    expect(handle.getAttribute('aria-label')).toBe('Resize name column');
+  });
+
+  it('removes handle listeners on destroy', () => {
+    setOffsetWidth(th, 150);
+    fixture.destroy();
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    expect(host.widths).toHaveLength(0);
+  });
+});

--- a/src/app/directives/column-resize.spec.ts
+++ b/src/app/directives/column-resize.spec.ts
@@ -151,6 +151,50 @@ describe('ColumnResize', () => {
     expect(host.widths).toHaveLength(emitCount);
   });
 
+  it('stops tracking pointer movement after pointercancel', () => {
+    setOffsetWidth(th, 150);
+
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointercancel', { bubbles: true }));
+    const emitCount = host.widths.length;
+
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 500, bubbles: true }));
+
+    expect(host.widths).toHaveLength(emitCount);
+  });
+
+  it('does not leak listeners when a new drag starts before release', () => {
+    setOffsetWidth(th, 150);
+
+    // First drag never receives pointerup, then a second drag begins.
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 340, bubbles: true }));
+
+    // Only the second drag's listener should fire (one emit for the move), not two.
+    expect(host.widths).toEqual([190]);
+  });
+
+  it('does not emit again when the clamped width is unchanged', () => {
+    setOffsetWidth(th, 150);
+
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 400, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 400, bubbles: true }));
+
+    expect(host.widths).toEqual([250]);
+  });
+
+  it('does not repeatedly emit while held against the minimum width', () => {
+    setOffsetWidth(th, 150);
+
+    handle.dispatchEvent(new MouseEvent('pointerdown', { clientX: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: 0, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('pointermove', { clientX: -50, bubbles: true }));
+
+    expect(host.widths).toEqual([60]);
+  });
+
   it('does not let handle clicks bubble to the header (avoids sorting)', () => {
     const parentClick = vi.fn();
     th.addEventListener('click', parentClick);

--- a/src/app/directives/column-resize.ts
+++ b/src/app/directives/column-resize.ts
@@ -29,6 +29,7 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
   private handle?: HTMLElement;
   private startX = 0;
   private startWidth = 0;
+  private lastEmittedWidth?: number;
   private readonly cleanups: (() => void)[] = [];
   private readonly pointerCleanups: (() => void)[] = [];
 
@@ -72,6 +73,10 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
     event.preventDefault();
     event.stopPropagation();
 
+    // Clear any listeners from a prior drag that never received pointerup
+    // (e.g. a second pointerdown before release) to avoid leaks/duplicate emits.
+    this.releasePointer();
+
     this.startX = event.clientX;
     this.startWidth = this.element.nativeElement.offsetWidth;
 
@@ -80,6 +85,9 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
         this.onPointerMove(moveEvent);
       }),
       this.renderer.listen(this.document, 'pointerup', () => {
+        this.releasePointer();
+      }),
+      this.renderer.listen(this.document, 'pointercancel', () => {
         this.releasePointer();
       }),
     );
@@ -116,6 +124,12 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
 
   private applyWidth(width: number): void {
     const clamped = this.clampWidth(width);
+
+    if (clamped === this.lastEmittedWidth) {
+      return;
+    }
+
+    this.lastEmittedWidth = clamped;
     this.handle?.setAttribute('aria-valuenow', `${clamped}`);
     this.widthChange.emit(clamped);
   }

--- a/src/app/directives/column-resize.ts
+++ b/src/app/directives/column-resize.ts
@@ -35,10 +35,12 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
   private readonly pointerCleanups: (() => void)[] = [];
 
   constructor() {
-    // Keep the separator's range attributes in sync with the inputs. If the
-    // bounds change at runtime, refresh aria-valuemin/max and re-clamp an
-    // already-resized column so the emitted width can't contradict the range.
+    // Keep the separator's label and range attributes in sync with the inputs.
+    // If the column or bounds change at runtime, refresh aria-label/valuemin/valuemax
+    // and re-clamp an already-resized column so the emitted width can't contradict
+    // the range.
     effect(() => {
+      const column = this.column();
       const min = this.minWidth();
       const max = this.maxWidth();
       const handle = this.handle;
@@ -47,6 +49,7 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
         return;
       }
 
+      handle.setAttribute('aria-label', `Resize ${column} column`);
       handle.setAttribute('aria-valuemin', `${min}`);
       handle.setAttribute('aria-valuemax', `${max}`);
 
@@ -58,7 +61,11 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
 
   ngAfterViewInit(): void {
     const host = this.element.nativeElement;
-    this.renderer.setStyle(host, 'position', 'relative');
+    // Only establish a positioning context when the cell isn't already positioned,
+    // so we don't override Material's sticky header (position: sticky).
+    if (this.document.defaultView?.getComputedStyle(host).position === 'static') {
+      this.renderer.setStyle(host, 'position', 'relative');
+    }
 
     const handle = this.renderer.createElement('span') as HTMLElement;
     this.renderer.addClass(handle, 'column-resize-handle');

--- a/src/app/directives/column-resize.ts
+++ b/src/app/directives/column-resize.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   OnDestroy,
   Renderer2,
+  effect,
   inject,
   input,
   output,
@@ -32,6 +33,28 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
   private lastEmittedWidth?: number;
   private readonly cleanups: (() => void)[] = [];
   private readonly pointerCleanups: (() => void)[] = [];
+
+  constructor() {
+    // Keep the separator's range attributes in sync with the inputs. If the
+    // bounds change at runtime, refresh aria-valuemin/max and re-clamp an
+    // already-resized column so the emitted width can't contradict the range.
+    effect(() => {
+      const min = this.minWidth();
+      const max = this.maxWidth();
+      const handle = this.handle;
+
+      if (!handle) {
+        return;
+      }
+
+      handle.setAttribute('aria-valuemin', `${min}`);
+      handle.setAttribute('aria-valuemax', `${max}`);
+
+      if (this.lastEmittedWidth !== undefined) {
+        this.applyWidth(this.lastEmittedWidth);
+      }
+    });
+  }
 
   ngAfterViewInit(): void {
     const host = this.element.nativeElement;
@@ -70,6 +93,12 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
   }
 
   private onPointerDown(event: PointerEvent): void {
+    // Only the primary (left) button starts a resize; let secondary buttons
+    // (e.g. right-click) fall through so the context menu behaves normally.
+    if (event.button !== 0) {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/app/directives/column-resize.ts
+++ b/src/app/directives/column-resize.ts
@@ -22,6 +22,7 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
 
   readonly column = input.required<string>({ alias: 'appColumnResize' });
   readonly minWidth = input(60);
+  readonly maxWidth = input(1000);
 
   readonly widthChange = output<number>();
 
@@ -41,7 +42,8 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
     this.renderer.setAttribute(handle, 'aria-orientation', 'vertical');
     this.renderer.setAttribute(handle, 'aria-label', `Resize ${this.column()} column`);
     this.renderer.setAttribute(handle, 'aria-valuemin', `${this.minWidth()}`);
-    this.renderer.setAttribute(handle, 'aria-valuenow', `${Math.round(host.offsetWidth)}`);
+    this.renderer.setAttribute(handle, 'aria-valuemax', `${this.maxWidth()}`);
+    this.renderer.setAttribute(handle, 'aria-valuenow', `${this.clampWidth(host.offsetWidth)}`);
     this.renderer.setAttribute(handle, 'tabindex', '0');
     this.renderer.appendChild(host, handle);
     this.handle = handle;
@@ -86,8 +88,7 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
   }
 
   private onPointerMove(event: PointerEvent): void {
-    const width = Math.max(this.minWidth(), this.startWidth + (event.clientX - this.startX));
-    this.applyWidth(width);
+    this.applyWidth(this.startWidth + (event.clientX - this.startX));
   }
 
   private releasePointer(): void {
@@ -106,13 +107,16 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
     event.stopPropagation();
 
     const delta = event.key === 'ArrowRight' ? KEYBOARD_STEP : -KEYBOARD_STEP;
-    const width = Math.max(this.minWidth(), this.element.nativeElement.offsetWidth + delta);
-    this.applyWidth(width);
+    this.applyWidth(this.element.nativeElement.offsetWidth + delta);
+  }
+
+  private clampWidth(width: number): number {
+    return Math.round(Math.min(this.maxWidth(), Math.max(this.minWidth(), width)));
   }
 
   private applyWidth(width: number): void {
-    const rounded = Math.round(width);
-    this.handle?.setAttribute('aria-valuenow', `${rounded}`);
-    this.widthChange.emit(rounded);
+    const clamped = this.clampWidth(width);
+    this.handle?.setAttribute('aria-valuenow', `${clamped}`);
+    this.widthChange.emit(clamped);
   }
 }

--- a/src/app/directives/column-resize.ts
+++ b/src/app/directives/column-resize.ts
@@ -40,6 +40,8 @@ export class ColumnResize implements AfterViewInit, OnDestroy {
     this.renderer.setAttribute(handle, 'role', 'separator');
     this.renderer.setAttribute(handle, 'aria-orientation', 'vertical');
     this.renderer.setAttribute(handle, 'aria-label', `Resize ${this.column()} column`);
+    this.renderer.setAttribute(handle, 'aria-valuemin', `${this.minWidth()}`);
+    this.renderer.setAttribute(handle, 'aria-valuenow', `${Math.round(host.offsetWidth)}`);
     this.renderer.setAttribute(handle, 'tabindex', '0');
     this.renderer.appendChild(host, handle);
     this.handle = handle;

--- a/src/app/directives/column-resize.ts
+++ b/src/app/directives/column-resize.ts
@@ -1,0 +1,116 @@
+import { DOCUMENT } from '@angular/common';
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  OnDestroy,
+  Renderer2,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+
+const KEYBOARD_STEP = 16;
+
+@Directive({
+  selector: '[appColumnResize]',
+})
+export class ColumnResize implements AfterViewInit, OnDestroy {
+  private readonly element = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private readonly document = inject(DOCUMENT);
+
+  readonly column = input.required<string>({ alias: 'appColumnResize' });
+  readonly minWidth = input(60);
+
+  readonly widthChange = output<number>();
+
+  private handle?: HTMLElement;
+  private startX = 0;
+  private startWidth = 0;
+  private readonly cleanups: (() => void)[] = [];
+  private readonly pointerCleanups: (() => void)[] = [];
+
+  ngAfterViewInit(): void {
+    const host = this.element.nativeElement;
+    this.renderer.setStyle(host, 'position', 'relative');
+
+    const handle = this.renderer.createElement('span') as HTMLElement;
+    this.renderer.addClass(handle, 'column-resize-handle');
+    this.renderer.setAttribute(handle, 'role', 'separator');
+    this.renderer.setAttribute(handle, 'aria-orientation', 'vertical');
+    this.renderer.setAttribute(handle, 'aria-label', `Resize ${this.column()} column`);
+    this.renderer.setAttribute(handle, 'tabindex', '0');
+    this.renderer.appendChild(host, handle);
+    this.handle = handle;
+
+    this.cleanups.push(
+      this.renderer.listen(handle, 'pointerdown', (event: PointerEvent) => {
+        this.onPointerDown(event);
+      }),
+      this.renderer.listen(handle, 'keydown', (event: KeyboardEvent) => {
+        this.onKeyDown(event);
+      }),
+      this.renderer.listen(handle, 'click', (event: MouseEvent) => {
+        event.stopPropagation();
+      }),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.releasePointer();
+    for (const cleanup of this.cleanups) {
+      cleanup();
+    }
+  }
+
+  private onPointerDown(event: PointerEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.startX = event.clientX;
+    this.startWidth = this.element.nativeElement.offsetWidth;
+
+    this.pointerCleanups.push(
+      this.renderer.listen(this.document, 'pointermove', (moveEvent: PointerEvent) => {
+        this.onPointerMove(moveEvent);
+      }),
+      this.renderer.listen(this.document, 'pointerup', () => {
+        this.releasePointer();
+      }),
+    );
+
+    this.handle?.setPointerCapture?.(event.pointerId);
+  }
+
+  private onPointerMove(event: PointerEvent): void {
+    const width = Math.max(this.minWidth(), this.startWidth + (event.clientX - this.startX));
+    this.applyWidth(width);
+  }
+
+  private releasePointer(): void {
+    while (this.pointerCleanups.length > 0) {
+      const cleanup = this.pointerCleanups.pop();
+      cleanup?.();
+    }
+  }
+
+  private onKeyDown(event: KeyboardEvent): void {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const delta = event.key === 'ArrowRight' ? KEYBOARD_STEP : -KEYBOARD_STEP;
+    const width = Math.max(this.minWidth(), this.element.nativeElement.offsetWidth + delta);
+    this.applyWidth(width);
+  }
+
+  private applyWidth(width: number): void {
+    const rounded = Math.round(width);
+    this.handle?.setAttribute('aria-valuenow', `${rounded}`);
+    this.widthChange.emit(rounded);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -92,3 +92,36 @@ body {
 .bg-tertiary {
   background-color: mat.get-theme-color($light-theme, tertiary, 90) !important;
 }
+
+// Column resize handle is created dynamically by the ColumnResize directive via
+// Renderer2, so it never receives a component view-encapsulation attribute. These
+// styles must live in the global stylesheet to apply to it.
+.column-resize-handle {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  width: 12px;
+  cursor: col-resize;
+  touch-action: none;
+  user-select: none;
+  z-index: 2;
+}
+
+.column-resize-handle::after {
+  content: '';
+  position: absolute;
+  inset-block: 25%;
+  inset-inline-end: 4px;
+  width: 2px;
+  background: rgb(0 0 0 / 24%);
+}
+
+.column-resize-handle:hover::after,
+.column-resize-handle:focus-visible::after {
+  background: var(--mat-sys-primary, #3f51b5);
+}
+
+.column-resize-handle:focus-visible {
+  outline: 2px solid var(--mat-sys-primary, #3f51b5);
+  outline-offset: -2px;
+}


### PR DESCRIPTION
# Pull Request

## Description

Adds the ability to resize `MatTable` columns by dragging the right edge of each
column header, plus keyboard support for accessibility.

### What's new

- **`ColumnResize` directive (`[appColumnResize]`)** — attaches a grab handle to the
  right edge of each header `th`.
  - **Mouse:** click-and-drag the handle to resize; the whole column (header + body
    cells) follows.
  - **Keyboard:** the handle is focusable; `ArrowLeft`/`ArrowRight` resize in 16px
    steps. Widths are clamped to a configurable minimum (default 60px).
  - **Accessible:** the handle is a `role="separator"` with `aria-orientation`,
    `aria-label`, and `aria-valuenow`/`aria-valuemin` kept in sync.
  - **Doesn't hijack sorting** — pointer/click events on the handle stop propagation,
    so grabbing the handle never triggers `mat-sort-header`.
- **`MatTable` wiring** — a `columnWidths` signal tracks per-column widths, bound via
  `[style.width.px]` on each header. The table uses `table-layout: fixed` and
  stretches to fill its container.
- **Trailing spacer column** — a zero-width flexible column absorbs any surplus space
  so the resizable columns always render at their exact specified widths in both the
  "stretch to fill" (few columns) and "horizontal scroll" (many columns) regimes.

### Why the spacer column

With `table-layout: fixed`, when the table is wider than the sum of the column widths
the browser redistributes the surplus proportionally onto the real columns. That made
the rendered width diverge from the intended width and caused drags to jump/run away
when only a few columns were visible. Routing all slack into a dedicated spacer column
keeps rendered width == intended width, so dragging is smooth and exact everywhere.

### Notes / trade-offs

- Handle styles live in the **global** `styles.scss` (not the component's scoped SCSS):
  the handle element is created dynamically via `Renderer2`, so it doesn't receive the
  component's view-encapsulation attribute and scoped styles wouldn't apply to it.
- This branch also folds in a few incidental changes: rendering links/images in table
  cells, a minor column-chooser spacing tweak, a `lint-staged` npm-script/pre-commit
  hook adjustment, and dependency lockfile refreshes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor or code cleanup (no behavior change)
- [ ] Documentation update
- [x] Dependency update

## How to Test

1. Run `npm run start` and open `http://localhost:4200/`.
2. On the **Mat Table** tab, hover the right edge of any column header — the cursor
   becomes a resize (`col-resize`) grip.
3. Click and drag the grip left/right and confirm the column (header + body cells)
   resizes smoothly and content clips with an ellipsis.
4. Tab to a grip and press `ArrowLeft`/`ArrowRight` to confirm keyboard resizing.
5. Click a column header (not the grip) and confirm sorting still works, and that
   clicking the grip does **not** sort.
6. Open **Edit Columns** and reduce to just a couple of columns: the table stretches to
   fill the width with no empty space, and dragging stays smooth (no jumping).
7. Enable many columns so the table scrolls horizontally and confirm resizing is exact.

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm run test:unit` passes with no failures
- [x] Unit tests added or updated to cover new or changed behavior
- [ ] Documentation updated where applicable