### PR TITLE
Represent Mat Table columns as typed `ColumnDefinition` (+ image/link rendering, spectral URL fix)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,52 @@
 # Pull Request
 
-## Description
+## Summary
 
-Describe what this PR changes and why. Include relevant context, motivation, and any trade-offs made.
+Explain what this PR changes and why. Include motivation, context, and any
+trade-offs or decisions a reviewer should be aware of.
 
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that changes existing behavior)
-- [ ] Refactor or code cleanup (no behavior change)
-- [ ] Documentation update
+- [ ] Breaking change (fix or feature that alters existing behavior)
+- [ ] Refactor or cleanup (no behavior change)
+- [ ] Tests (unit, scripts, or Playwright e2e)
+- [ ] Build, CI, or tooling
 - [ ] Dependency update
+- [ ] Documentation or AI instructions
+
+## Areas Touched
+
+- [ ] Angular app (`src/`)
+- [ ] End-to-end tests (`tests/`)
+- [ ] Node scripts (`scripts/`)
+- [ ] CI or workflows (`.github/`)
+- [ ] AI instructions (`AGENTS.md` and its generated copies)
+- [ ] Dependencies (`package.json` / `package-lock.json`)
 
 ## Related Issues
 
 Closes #
 
-## How to Test
+## How to Verify
 
-Provide clear steps for reviewers to verify the changes work as expected.
+Steps a reviewer can follow to confirm the change behaves as expected.
 
-1. Run `npm run start` and open `http://localhost:4200/`
-2. ...
+1. `npm ci`
+2. `npm run start`, then open http://localhost:4200/
+3. ...
+
+For UI changes, attach before/after screenshots or a short recording.
 
 ## Checklist
 
-- [ ] `npm run lint` passes with no errors
-- [ ] `npm run test:unit` passes with no failures
-- [ ] Unit tests added or updated to cover new or changed behavior
+Mirror the CI pipeline in `.github/workflows/actions.yml` before requesting a review.
+
+- [ ] Edited `AGENTS.md` (not the generated copies), then ran `npm run sync:agent-instructions`; `npm run sync:agent-instructions:check` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes (unit, scripts, and Playwright e2e)
+- [ ] `npm run build` succeeds
+- [ ] Tests added or updated to cover new or changed behavior
+- [ ] UI changes meet accessibility requirements (AXE clean, WCAG AA)
 - [ ] Documentation updated where applicable

--- a/src/app/components/mat-table/column-select/column-select.html
+++ b/src/app/components/mat-table/column-select/column-select.html
@@ -1,11 +1,11 @@
 <mat-card class="example-card" appearance="outlined">
   <mat-card-content class="card-content">
-    @for (column of fullListOfColumns(); track column) {
+    @for (column of fullListOfColumns(); track column.name) {
       <mat-checkbox
-        [checked]="columnsToDisplay().includes(column)"
+        [checked]="isColumnDisplayed(column)"
         (change)="setColumnsToDisplay($event, column)"
       >
-        {{ column }}
+        {{ column.displayName }}
       </mat-checkbox>
     }
   </mat-card-content>

--- a/src/app/components/mat-table/column-select/column-select.spec.ts
+++ b/src/app/components/mat-table/column-select/column-select.spec.ts
@@ -1,13 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCheckbox, MatCheckboxChange } from '@angular/material/checkbox';
 import { By } from '@angular/platform-browser';
+import { ColumnDefinition } from '../../../interfaces/column-definition';
 import { ColumnSelect } from './column-select';
 
 describe('ColumnSelect', () => {
   let component: ColumnSelect;
   let fixture: ComponentFixture<ColumnSelect>;
 
-  const mockColumns = ['name', 'atomic_mass', 'symbol', 'number'];
+  const mockColumns: ColumnDefinition[] = [
+    { name: 'name', displayName: 'Name', isSortable: true, width: 150 },
+    { name: 'atomic_mass', displayName: 'Atomic Mass', isSortable: true, width: 150 },
+    { name: 'symbol', displayName: 'Symbol', isSortable: true, width: 150 },
+    { name: 'number', displayName: 'Number', isSortable: true, width: 150 },
+  ];
+  const [nameColumn, atomicMassColumn, symbolColumn, numberColumn] = mockColumns;
+  const sourceColumn: ColumnDefinition = {
+    name: 'source',
+    displayName: 'Source',
+    isSortable: false,
+    width: 150,
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -43,7 +56,7 @@ describe('ColumnSelect', () => {
     beforeEach(() => {
       TestBed.runInInjectionContext(() => {
         fixture.componentRef.setInput('fullListOfColumns', mockColumns);
-        fixture.componentRef.setInput('columnsToDisplay', ['name', 'symbol']);
+        fixture.componentRef.setInput('columnsToDisplay', [nameColumn, symbolColumn]);
       });
       fixture.detectChanges();
     });
@@ -53,16 +66,16 @@ describe('ColumnSelect', () => {
     });
 
     it('should expose columnsToDisplay as model signal', () => {
-      expect(component.columnsToDisplay()).toEqual(['name', 'symbol']);
+      expect(component.columnsToDisplay()).toEqual([nameColumn, symbolColumn]);
     });
 
     it('should update columnsToDisplay when model changes', () => {
       TestBed.runInInjectionContext(() => {
-        fixture.componentRef.setInput('columnsToDisplay', ['atomic_mass', 'number']);
+        fixture.componentRef.setInput('columnsToDisplay', [atomicMassColumn, numberColumn]);
       });
       fixture.detectChanges();
 
-      expect(component.columnsToDisplay()).toEqual(['atomic_mass', 'number']);
+      expect(component.columnsToDisplay()).toEqual([atomicMassColumn, numberColumn]);
     });
   });
 
@@ -70,27 +83,27 @@ describe('ColumnSelect', () => {
     beforeEach(() => {
       TestBed.runInInjectionContext(() => {
         fixture.componentRef.setInput('fullListOfColumns', mockColumns);
-        fixture.componentRef.setInput('columnsToDisplay', ['name', 'symbol']);
+        fixture.componentRef.setInput('columnsToDisplay', [nameColumn, symbolColumn]);
       });
       fixture.detectChanges();
     });
 
     it('adds a checked column while preserving full list order', () => {
-      component.setColumnsToDisplay({ checked: true } as MatCheckboxChange, 'atomic_mass');
-      expect(component.columnsToDisplay()).toEqual(['name', 'atomic_mass', 'symbol']);
+      component.setColumnsToDisplay({ checked: true } as MatCheckboxChange, atomicMassColumn);
+      expect(component.columnsToDisplay()).toEqual([nameColumn, atomicMassColumn, symbolColumn]);
     });
 
     it('removes an unchecked column', () => {
-      component.setColumnsToDisplay({ checked: false } as MatCheckboxChange, 'name');
-      expect(component.columnsToDisplay()).toEqual(['symbol']);
+      component.setColumnsToDisplay({ checked: false } as MatCheckboxChange, nameColumn);
+      expect(component.columnsToDisplay()).toEqual([symbolColumn]);
     });
 
     it('preserves selected columns that are not in the full list when toggling', () => {
-      component.columnsToDisplay.set(['name', 'source']);
+      component.columnsToDisplay.set([nameColumn, sourceColumn]);
 
-      component.setColumnsToDisplay({ checked: true } as MatCheckboxChange, 'atomic_mass');
+      component.setColumnsToDisplay({ checked: true } as MatCheckboxChange, atomicMassColumn);
 
-      expect(component.columnsToDisplay()).toEqual(['name', 'atomic_mass', 'source']);
+      expect(component.columnsToDisplay()).toEqual([nameColumn, atomicMassColumn, sourceColumn]);
     });
   });
 
@@ -98,7 +111,7 @@ describe('ColumnSelect', () => {
     beforeEach(() => {
       TestBed.runInInjectionContext(() => {
         fixture.componentRef.setInput('fullListOfColumns', mockColumns);
-        fixture.componentRef.setInput('columnsToDisplay', ['name', 'symbol']);
+        fixture.componentRef.setInput('columnsToDisplay', [nameColumn, symbolColumn]);
       });
       fixture.detectChanges();
     });
@@ -106,6 +119,14 @@ describe('ColumnSelect', () => {
     it('renders one checkbox per available column', () => {
       const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
       expect(checkboxes).toHaveLength(mockColumns.length);
+    });
+
+    it('renders the human-friendly display name for each column', () => {
+      const labels = fixture.debugElement
+        .queryAll(By.css('mat-checkbox'))
+        .map((checkbox) => (checkbox.nativeElement as HTMLElement).textContent?.trim());
+
+      expect(labels).toEqual(mockColumns.map((column) => column.displayName));
     });
 
     it('reflects selected columns in checkbox checked states', () => {
@@ -126,11 +147,11 @@ describe('ColumnSelect', () => {
 
       checkboxes[2].triggerEventHandler('change', { checked: false });
       fixture.detectChanges();
-      expect(component.columnsToDisplay()).toEqual(['name']);
+      expect(component.columnsToDisplay()).toEqual([nameColumn]);
 
       checkboxes[1].triggerEventHandler('change', { checked: true });
       fixture.detectChanges();
-      expect(component.columnsToDisplay()).toEqual(['name', 'atomic_mass']);
+      expect(component.columnsToDisplay()).toEqual([nameColumn, atomicMassColumn]);
     });
   });
 });

--- a/src/app/components/mat-table/column-select/column-select.ts
+++ b/src/app/components/mat-table/column-select/column-select.ts
@@ -1,6 +1,7 @@
 import { Component, input, model } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+import { ColumnDefinition } from '../../../interfaces/column-definition';
 
 @Component({
   selector: 'app-column-select',
@@ -9,21 +10,25 @@ import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox
   styleUrl: './column-select.scss',
 })
 export class ColumnSelect {
-  readonly fullListOfColumns = input.required<string[]>();
-  readonly columnsToDisplay = model.required<string[]>();
+  readonly fullListOfColumns = input.required<ColumnDefinition[]>();
+  readonly columnsToDisplay = model.required<ColumnDefinition[]>();
 
-  setColumnsToDisplay(event: MatCheckboxChange, column: string) {
+  isColumnDisplayed(column: ColumnDefinition): boolean {
+    return this.columnsToDisplay().some((displayed) => displayed.name === column.name);
+  }
+
+  setColumnsToDisplay(event: MatCheckboxChange, column: ColumnDefinition) {
     if (event.checked) {
       this.columnsToDisplay.update((currentColumns) => {
-        if (currentColumns.includes(column)) {
+        if (currentColumns.some((currentColumn) => currentColumn.name === column.name)) {
           return currentColumns;
         }
 
         const fullListOfColumns = this.fullListOfColumns();
 
         return [...currentColumns, column].sort((a, b) => {
-          const columnAIndex = fullListOfColumns.indexOf(a);
-          const columnBIndex = fullListOfColumns.indexOf(b);
+          const columnAIndex = fullListOfColumns.findIndex((current) => current.name === a.name);
+          const columnBIndex = fullListOfColumns.findIndex((current) => current.name === b.name);
 
           if (columnAIndex === -1 && columnBIndex === -1) {
             return 0;
@@ -42,7 +47,7 @@ export class ColumnSelect {
     }
 
     this.columnsToDisplay.update((currentColumns) => {
-      return currentColumns.filter((currentColumn) => currentColumn !== column);
+      return currentColumns.filter((currentColumn) => currentColumn.name !== column.name);
     });
   }
 }

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -37,38 +37,50 @@
     matSort
   >
     <!-- Columns Definitions -->
-    @for (column of columnsToDisplay(); track column) {
-      <ng-container matColumnDef="{{ column }}">
-        <th
-          mat-header-cell
-          *matHeaderCellDef
-          mat-sort-header
-          [appColumnResize]="column"
-          [style.width.px]="columnWidth(column)"
-          (widthChange)="setColumnWidth(column, $event)"
-        >
-          {{ column }}
-        </th>
-        @if (column === 'source') {
+    @for (column of columnsToDisplay(); track column.name) {
+      <ng-container matColumnDef="{{ column.name }}">
+        @if (column.isSortable) {
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            mat-sort-header
+            [appColumnResize]="column.name"
+            [style.width.px]="columnWidth(column)"
+            (widthChange)="setColumnWidth(column.name, $event)"
+          >
+            {{ column.displayName }}
+          </th>
+        } @else {
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            [appColumnResize]="column.name"
+            [style.width.px]="columnWidth(column)"
+            (widthChange)="setColumnWidth(column.name, $event)"
+          >
+            {{ column.displayName }}
+          </th>
+        }
+        @if (column.name === 'source') {
           <td mat-cell *matCellDef="let element">
-            <a [href]="element[column]" target="_blank" rel="noopener noreferrer">
-              {{ element[column] }}
+            <a [href]="element[column.name]" target="_blank" rel="noopener noreferrer">
+              {{ element[column.name] }}
             </a>
           </td>
-        } @else if (column === 'image') {
+        } @else if (column.name === 'image') {
           <td mat-cell *matCellDef="let element">
             <span class="image-thumb">
-              <img [ngSrc]="element[column].url" [alt]="element[column].title" fill />
+              <img [ngSrc]="element[column.name].url" [alt]="element[column.name].title" fill />
             </span>
           </td>
         } @else {
           <td mat-cell *matCellDef="let element">
-            {{ element[column] }}
+            {{ element[column.name] }}
           </td>
         }
-        @if (column === 'name') {
+        @if (column.name === 'name') {
           <td mat-footer-cell *matFooterCellDef class="bg-primary">Total # of elements:</td>
-        } @else if (column === 'atomic_mass') {
+        } @else if (column.name === 'atomic_mass') {
           <td mat-footer-cell *matFooterCellDef class="bg-primary">{{ dataSource.data.length }}</td>
         } @else {
           <td mat-footer-cell *matFooterCellDef class="bg-primary"></td>

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -61,17 +61,27 @@
             {{ column.displayName }}
           </th>
         }
-        @if (column.name === 'source') {
+        @if (column.name === 'source' || column.name === 'bohr_model_3d') {
           <td mat-cell *matCellDef="let element">
-            <a [href]="element[column.name]" target="_blank" rel="noopener noreferrer">
-              {{ element[column.name] }}
-            </a>
+            @if (element[column.name]) {
+              <a [href]="element[column.name]" target="_blank" rel="noopener noreferrer">
+                {{ element[column.name] }}
+              </a>
+            }
           </td>
         } @else if (column.name === 'image') {
           <td mat-cell *matCellDef="let element">
             <span class="image-thumb">
               <img [ngSrc]="element[column.name].url" [alt]="element[column.name].title" fill />
             </span>
+          </td>
+        } @else if (column.name === 'bohr_model_image' || column.name === 'spectral_img') {
+          <td mat-cell *matCellDef="let element">
+            @if (element[column.name]) {
+              <span class="image-thumb">
+                <img [ngSrc]="element[column.name]" [alt]="imageAlt(element, column)" fill />
+              </span>
+            }
           </td>
         } @else {
           <td mat-cell *matCellDef="let element">

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -451,6 +451,65 @@ describe('MatTable', () => {
     });
   });
 
+  describe('Special Column Rendering', () => {
+    function visibleElements() {
+      const pageSize = component.paginator()?.pageSize ?? 25;
+      return component.dataSource.data.slice(0, pageSize);
+    }
+
+    beforeEach(() => {
+      component.columnsToDisplay.set(
+        columns('name', 'bohr_model_image', 'bohr_model_3d', 'spectral_img'),
+      );
+      fixture.detectChanges();
+    });
+
+    it('renders bohr_model_image values as optimized images', () => {
+      const images = fixture.debugElement.queryAll(By.css('td.mat-column-bohr_model_image img'));
+      const expected = visibleElements().filter((element) => element.bohr_model_image).length;
+
+      expect(expected).toBeGreaterThan(0);
+      expect(images.length).toBe(expected);
+    });
+
+    it('renders spectral_img values as optimized images and omits null ones', () => {
+      const visible = visibleElements();
+      const cells = fixture.debugElement.queryAll(
+        By.css('td.mat-mdc-cell.mat-column-spectral_img'),
+      );
+      const images = fixture.debugElement.queryAll(By.css('td.mat-column-spectral_img img'));
+      const nonNullCount = visible.filter((element) => element.spectral_img).length;
+
+      expect(cells.length).toBe(visible.length);
+      expect(images.length).toBe(nonNullCount);
+      // At least one visible element has a null spectral_img, proving the null guard.
+      expect(nonNullCount).toBeLessThan(cells.length);
+    });
+
+    it('renders bohr_model_3d values as external links', () => {
+      const links = fixture.debugElement.queryAll(By.css('td.mat-column-bohr_model_3d a'));
+      const expected = visibleElements().filter((element) => element.bohr_model_3d).length;
+
+      expect(expected).toBeGreaterThan(0);
+      expect(links.length).toBe(expected);
+      links.forEach((link) => {
+        const anchor = link.nativeElement as HTMLAnchorElement;
+        expect(anchor.getAttribute('target')).toBe('_blank');
+        expect(anchor.getAttribute('rel')).toBe('noopener noreferrer');
+      });
+    });
+
+    it('gives images a descriptive alt derived from the element and column', () => {
+      const firstImage = fixture.debugElement.query(By.css('td.mat-column-bohr_model_image img'));
+      const firstElement = visibleElements().find((element) => element.bohr_model_image);
+
+      expect(firstElement).toBeTruthy();
+      expect((firstImage.nativeElement as HTMLImageElement).getAttribute('alt')).toBe(
+        `${firstElement?.name} bohr model image`,
+      );
+    });
+  });
+
   describe('Template Integration - Table Headers and Footers', () => {
     it('renders table header for each column in columnsToRender', () => {
       const headers = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -2,6 +2,7 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { vi } from 'vitest';
+import { ColumnDefinition } from '../../interfaces/column-definition';
 import { FilterState } from '../../interfaces/filter-state';
 import { ColumnSelect } from './column-select/column-select';
 import {
@@ -12,6 +13,24 @@ import {
   MatTable,
   RESIZE_SPACER_COLUMN,
 } from './mat-table';
+
+const COLUMN_BY_NAME = new Map<string, ColumnDefinition>(
+  [...FULL_LIST_OF_COLUMNS, ...DEFAULT_COLUMNS].map((column) => [column.name, column]),
+);
+
+function columns(...names: string[]): ColumnDefinition[] {
+  return names.map((name) => {
+    const column = COLUMN_BY_NAME.get(name);
+    if (!column) {
+      throw new Error(`Unknown column in test helper: ${name}`);
+    }
+    return column;
+  });
+}
+
+function columnNames(definitions: ColumnDefinition[]): string[] {
+  return definitions.map((column) => column.name);
+}
 
 describe('MatTable', () => {
   let component: MatTable;
@@ -45,12 +64,15 @@ describe('MatTable', () => {
     });
 
     it('creates columnsToDisplayWithExpand by appending expand column', () => {
-      expect(component.columnsToDisplayWithExpand()).toEqual([...DEFAULT_COLUMNS, 'expand']);
+      expect(component.columnsToDisplayWithExpand()).toEqual([
+        ...columnNames(DEFAULT_COLUMNS),
+        'expand',
+      ]);
     });
 
     it('creates columnsToRender by appending the expand and spacer columns', () => {
       expect(component.columnsToRender()).toEqual([
-        ...DEFAULT_COLUMNS,
+        ...columnNames(DEFAULT_COLUMNS),
         'expand',
         RESIZE_SPACER_COLUMN,
       ]);
@@ -86,15 +108,18 @@ describe('MatTable', () => {
 
   describe('Column Management', () => {
     it('updates columnsToDisplay signal', () => {
-      const newColumns = ['name', 'symbol'];
+      const newColumns = columns('name', 'symbol');
       component.columnsToDisplay.set(newColumns);
       expect(component.columnsToDisplay()).toEqual(newColumns);
     });
 
     it('columnsToDisplayWithExpand updates when columnsToDisplay changes', () => {
-      const newColumns = ['name', 'symbol', 'atomic_mass'];
+      const newColumns = columns('name', 'symbol', 'atomic_mass');
       component.columnsToDisplay.set(newColumns);
-      expect(component.columnsToDisplayWithExpand()).toEqual([...newColumns, 'expand']);
+      expect(component.columnsToDisplayWithExpand()).toEqual([
+        ...columnNames(newColumns),
+        'expand',
+      ]);
     });
 
     it('handles empty array of displayed columns', () => {
@@ -109,7 +134,7 @@ describe('MatTable', () => {
     });
 
     it('can reset displayed columns to DEFAULT_COLUMNS', () => {
-      component.columnsToDisplay.set(['name', 'symbol']);
+      component.columnsToDisplay.set(columns('name', 'symbol'));
       expect(component.columnsToDisplay()).not.toEqual(DEFAULT_COLUMNS);
 
       component.columnsToDisplay.set(DEFAULT_COLUMNS);
@@ -119,20 +144,23 @@ describe('MatTable', () => {
 
   describe('Column Resizing', () => {
     it('returns the default width for columns without an override', () => {
-      expect(component.columnWidth('name')).toBe(DEFAULT_COLUMN_WIDTH);
+      const [nameColumn] = columns('name');
+      expect(component.columnWidth(nameColumn)).toBe(DEFAULT_COLUMN_WIDTH);
     });
 
     it('stores and returns an explicit width for a column', () => {
+      const [nameColumn] = columns('name');
       component.setColumnWidth('name', 240);
-      expect(component.columnWidth('name')).toBe(240);
+      expect(component.columnWidth(nameColumn)).toBe(240);
     });
 
     it('preserves widths of other columns when one is resized', () => {
+      const [nameColumn, symbolColumn] = columns('name', 'symbol');
       component.setColumnWidth('name', 240);
       component.setColumnWidth('symbol', 90);
 
-      expect(component.columnWidth('name')).toBe(240);
-      expect(component.columnWidth('symbol')).toBe(90);
+      expect(component.columnWidth(nameColumn)).toBe(240);
+      expect(component.columnWidth(symbolColumn)).toBe(90);
     });
 
     it('computes tableWidth from default widths plus the expand column', () => {
@@ -147,7 +175,7 @@ describe('MatTable', () => {
     });
 
     it('recomputes tableWidth when displayed columns change', () => {
-      component.columnsToDisplay.set(['name', 'symbol']);
+      component.columnsToDisplay.set(columns('name', 'symbol'));
       expect(component.tableWidth()).toBe(2 * DEFAULT_COLUMN_WIDTH + EXPAND_COLUMN_WIDTH);
     });
 
@@ -414,7 +442,7 @@ describe('MatTable', () => {
 
       const columnSelect = fixture.debugElement.query(By.directive(ColumnSelect));
       expect(columnSelect).toBeTruthy();
-      const newColumns = ['name', 'symbol', 'atomic_mass'];
+      const newColumns = columns('name', 'symbol', 'atomic_mass');
 
       columnSelect.triggerEventHandler('columnsToDisplayChange', newColumns);
       fixture.detectChanges();
@@ -602,16 +630,30 @@ describe('MatTable', () => {
       expect(component.dataSource.sort).toBe(component.sort());
     });
 
-    it('sort headers correspond to displayed columns', () => {
+    it('sort headers are rendered only for sortable displayed columns', () => {
       const sortHeaders = fixture.debugElement.queryAll(By.css('[mat-sort-header]'));
       const sortHeaderTexts = sortHeaders.map((header) =>
-        ((header.nativeElement as HTMLElement).textContent ?? '').trim().toLowerCase(),
+        ((header.nativeElement as HTMLElement).textContent ?? '').trim(),
       );
 
-      const displayedColumns = component.columnsToDisplay().map((col) => col.toLowerCase());
+      const sortableDisplayNames = component
+        .columnsToDisplay()
+        .filter((column) => column.isSortable)
+        .map((column) => column.displayName);
+
+      expect(sortHeaderTexts.length).toBe(sortableDisplayNames.length);
       sortHeaderTexts.forEach((text) => {
-        expect(displayedColumns).toContain(text);
+        expect(sortableDisplayNames).toContain(text);
       });
+    });
+
+    it('does not render sort headers for non-sortable columns', () => {
+      const sortHeaderTexts = fixture.debugElement
+        .queryAll(By.css('[mat-sort-header]'))
+        .map((header) => ((header.nativeElement as HTMLElement).textContent ?? '').trim());
+
+      // `source` is displayed by default but is a non-sortable (link) column.
+      expect(sortHeaderTexts).not.toContain('Source');
     });
   });
 
@@ -620,7 +662,7 @@ describe('MatTable', () => {
       const initialHeaders = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
       const initialCount = initialHeaders.length;
 
-      component.columnsToDisplay.set(['name', 'symbol']);
+      component.columnsToDisplay.set(columns('name', 'symbol'));
       fixture.detectChanges();
 
       const updatedHeaders = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
@@ -629,7 +671,7 @@ describe('MatTable', () => {
     });
 
     it('expandedDetail row maintains proper colspan after column change', () => {
-      component.columnsToDisplay.set(['name', 'symbol']);
+      component.columnsToDisplay.set(columns('name', 'symbol'));
       fixture.detectChanges();
 
       // Find the detail row cell with the example-element-detail-wrapper
@@ -660,9 +702,9 @@ describe('MatTable', () => {
 
     it('handles rapid column changes', () => {
       expect(() => {
-        component.columnsToDisplay.set(['name']);
-        component.columnsToDisplay.set(['symbol']);
-        component.columnsToDisplay.set(['atomic_mass']);
+        component.columnsToDisplay.set(columns('name'));
+        component.columnsToDisplay.set(columns('symbol'));
+        component.columnsToDisplay.set(columns('atomic_mass'));
         component.columnsToDisplay.set(DEFAULT_COLUMNS);
       }).not.toThrow();
 

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -258,6 +258,10 @@ export class MatTable {
     return this.columnWidths()[column.name] ?? column.width;
   }
 
+  imageAlt(element: PeriodicElement, column: ColumnDefinition): string {
+    return `${element.name} ${column.displayName.toLowerCase()}`;
+  }
+
   setColumnWidth(column: string, width: number): void {
     this.columnWidths.update((widths) => ({ ...widths, [column]: width }));
   }

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -7,6 +7,7 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { ColumnResize } from '../../directives/column-resize';
+import { ColumnDefinition } from '../../interfaces/column-definition';
 import { ELEMENT_DATA } from '../../interfaces/data';
 import { FilterState } from '../../interfaces/filter-state';
 import { PeriodicElement } from '../../interfaces/periodic-element';
@@ -14,58 +15,133 @@ import { ColumnSelect } from './column-select/column-select';
 import { Filter } from './filter/filter';
 import { PeriodicElementDetail } from './periodic-element-detail/periodic-element-detail';
 
-export const FULL_LIST_OF_COLUMNS = [
-  'name',
-  'appearance',
-  'atomic_mass',
-  'boil',
-  'category',
-  'density',
-  'discovered_by',
-  'melt',
-  'molar_heat',
-  'named_by',
-  'number',
-  'period',
-  'group',
-  'phase',
-  'bohr_model_image',
-  'bohr_model_3d',
-  'spectral_img',
-  'summary',
-  'symbol',
-  'xpos',
-  'ypos',
-  'wxpos',
-  'wypos',
-  'shells',
-  'electron_configuration',
-  'electron_configuration_semantic',
-  'electron_affinity',
-  'electronegativity_pauling',
-  'ionization_energies',
-  'image',
-  'block',
-];
-
-export const DEFAULT_COLUMNS = [
-  'name',
-  'atomic_mass',
-  'symbol',
-  'number',
-  'category',
-  'period',
-  'group',
-  'phase',
-  'source',
-  'electron_configuration',
-  'electron_configuration_semantic',
-  'block',
-];
-
 export const DEFAULT_COLUMN_WIDTH = 150;
 export const EXPAND_COLUMN_WIDTH = 56;
 export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
+
+// Every column starts at DEFAULT_COLUMN_WIDTH for now; the explicit per-column
+// `width` makes it easy to tune each one to an appropriate value later.
+export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
+  { name: 'name', displayName: 'Name', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'appearance', displayName: 'Appearance', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  {
+    name: 'atomic_mass',
+    displayName: 'Atomic Mass',
+    isSortable: true,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  { name: 'boil', displayName: 'Boiling Point', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'category', displayName: 'Category', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'density', displayName: 'Density', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  {
+    name: 'discovered_by',
+    displayName: 'Discovered By',
+    isSortable: true,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  { name: 'melt', displayName: 'Melting Point', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'molar_heat', displayName: 'Molar Heat', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'named_by', displayName: 'Named By', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'number', displayName: 'Number', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'period', displayName: 'Period', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'group', displayName: 'Group', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'phase', displayName: 'Phase', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  {
+    name: 'bohr_model_image',
+    displayName: 'Bohr Model Image',
+    isSortable: false,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  {
+    name: 'bohr_model_3d',
+    displayName: 'Bohr Model 3D',
+    isSortable: false,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  {
+    name: 'spectral_img',
+    displayName: 'Spectral Image',
+    isSortable: false,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  { name: 'summary', displayName: 'Summary', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'symbol', displayName: 'Symbol', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'xpos', displayName: 'X Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'ypos', displayName: 'Y Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'wxpos', displayName: 'Wide X Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'wypos', displayName: 'Wide Y Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'shells', displayName: 'Shells', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  {
+    name: 'electron_configuration',
+    displayName: 'Electron Configuration',
+    isSortable: true,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  {
+    name: 'electron_configuration_semantic',
+    displayName: 'Electron Configuration (Semantic)',
+    isSortable: true,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  {
+    name: 'electron_affinity',
+    displayName: 'Electron Affinity',
+    isSortable: true,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  {
+    name: 'electronegativity_pauling',
+    displayName: 'Electronegativity (Pauling)',
+    isSortable: true,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  {
+    name: 'ionization_energies',
+    displayName: 'Ionization Energies',
+    isSortable: true,
+    width: DEFAULT_COLUMN_WIDTH,
+  },
+  { name: 'image', displayName: 'Image', isSortable: false, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'block', displayName: 'Block', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+];
+
+const COLUMN_DEFINITIONS_BY_NAME = new Map<string, ColumnDefinition>(
+  FULL_LIST_OF_COLUMNS.map((column) => [column.name, column]),
+);
+
+function requireColumn(name: string): ColumnDefinition {
+  const column = COLUMN_DEFINITIONS_BY_NAME.get(name);
+
+  if (!column) {
+    throw new Error(`Unknown column definition: ${name}`);
+  }
+
+  return column;
+}
+
+// `source` is shown by default but intentionally omitted from the column
+// chooser's full list, so it isn't part of FULL_LIST_OF_COLUMNS.
+const SOURCE_COLUMN: ColumnDefinition = {
+  name: 'source',
+  displayName: 'Source',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const DEFAULT_COLUMNS: ColumnDefinition[] = [
+  requireColumn('name'),
+  requireColumn('atomic_mass'),
+  requireColumn('symbol'),
+  requireColumn('number'),
+  requireColumn('category'),
+  requireColumn('period'),
+  requireColumn('group'),
+  requireColumn('phase'),
+  SOURCE_COLUMN,
+  requireColumn('electron_configuration'),
+  requireColumn('electron_configuration_semantic'),
+  requireColumn('block'),
+];
 
 @Component({
   selector: 'app-mat-table',
@@ -94,8 +170,11 @@ export class MatTable {
   readonly sort = viewChild(MatSort);
 
   readonly dataSource = new MatTableDataSource(ELEMENT_DATA.elements);
-  readonly columnsToDisplay = signal<string[]>(DEFAULT_COLUMNS);
-  readonly columnsToDisplayWithExpand = computed(() => [...this.columnsToDisplay(), 'expand']);
+  readonly columnsToDisplay = signal<ColumnDefinition[]>(DEFAULT_COLUMNS);
+  readonly columnsToDisplayWithExpand = computed(() => [
+    ...this.columnsToDisplay().map((column) => column.name),
+    'expand',
+  ]);
   // A trailing flexible spacer column absorbs any slack so the resizable columns
   // always render at their exact specified widths (never proportionally redistributed
   // by the fixed table layout), which keeps drag resizing stable when the table has
@@ -107,7 +186,7 @@ export class MatTable {
   readonly tableWidth = computed(() => {
     const widths = this.columnWidths();
     const dataTotal = this.columnsToDisplay().reduce(
-      (total, column) => total + (widths[column] ?? DEFAULT_COLUMN_WIDTH),
+      (total, column) => total + (widths[column.name] ?? column.width),
       0,
     );
 
@@ -175,8 +254,8 @@ export class MatTable {
     return this.expandedElement() === element;
   }
 
-  columnWidth(column: string): number {
-    return this.columnWidths()[column] ?? DEFAULT_COLUMN_WIDTH;
+  columnWidth(column: ColumnDefinition): number {
+    return this.columnWidths()[column.name] ?? column.width;
   }
 
   setColumnWidth(column: string, width: number): void {

--- a/src/app/interfaces/column-definition.ts
+++ b/src/app/interfaces/column-definition.ts
@@ -1,0 +1,6 @@
+export interface ColumnDefinition {
+  name: string;
+  displayName: string;
+  isSortable: boolean;
+  width: number;
+}

--- a/src/app/interfaces/data.ts
+++ b/src/app/interfaces/data.ts
@@ -22,7 +22,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_001_hydrogen/element_001_hydrogen_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_001_hydrogen/element_001_hydrogen.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Hydrogen_Spectra.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/e/e4/Hydrogen_Spectra.jpg',
       summary:
         'Hydrogen is a chemical element with chemical symbol H and atomic number 1. With an atomic weight of 1.00794 u, hydrogen is the lightest element on the periodic table. Its monatomic form (H) is the most abundant chemical substance in the Universe, constituting roughly 75% of all baryonic mass.',
       symbol: 'H',
@@ -66,7 +66,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_002_helium/element_002_helium_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_002_helium/element_002_helium.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Helium_spectrum.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/8/80/Helium_spectrum.jpg',
       summary:
         'Helium is a chemical element with symbol He and atomic number 2. It is a colorless, odorless, tasteless, non-toxic, inert, monatomic gas that heads the noble gas group in the periodic table. Its boiling and melting points are the lowest among all the elements.',
       symbol: 'He',
@@ -238,7 +238,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_006_carbon/element_006_carbon_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_006_carbon/element_006_carbon.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Carbon_Spectra.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/8/8c/Carbon_Spectra.jpg',
       summary:
         'Carbon (from Latin:carbo "coal") is a chemical element with symbol C and atomic number 6. On the periodic table, it is the first (row 2) of six elements in column (group) 14, which have in common the composition of their outer electron shell. It is nonmetallic and tetravalent—making four electrons available to form covalent chemical bonds.',
       symbol: 'C',
@@ -281,7 +281,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_007_nitrogen/element_007_nitrogen_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_007_nitrogen/element_007_nitrogen.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Nitrogen_Spectra.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/3/37/Nitrogen_Spectra.jpg',
       summary:
         'Nitrogen is a chemical element with symbol N and atomic number 7. It is the lightest pnictogen and at room temperature, it is a transparent, odorless diatomic gas. Nitrogen is a common element in the universe, estimated at about seventh in total abundance in the Milky Way and the Solar System.',
       symbol: 'N',
@@ -324,7 +324,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_008_oxygen/element_008_oxygen_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_008_oxygen/element_008_oxygen.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Oxygen_spectre.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/a/a0/Oxygen_spectre.jpg',
       summary:
         'Oxygen is a chemical element with symbol O and atomic number 8. It is a member of the chalcogen group on the periodic table and is a highly reactive nonmetal and oxidizing agent that readily forms compounds (notably oxides) with most elements. By mass, oxygen is the third-most abundant element in the universe, after hydrogen and helium.',
       symbol: 'O',
@@ -412,7 +412,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_010_neon/element_010_neon_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_010_neon/element_010_neon.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Neon_spectra.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/9/99/Neon_spectra.jpg',
       summary:
         'Neon is a chemical element with symbol Ne and atomic number 10. It is in group 18 (noble gases) of the periodic table. Neon is a colorless, odorless, inert monatomic gas under standard conditions, with about two-thirds the density of air.',
       symbol: 'Ne',
@@ -457,7 +457,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_011_sodium/element_011_sodium_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_011_sodium/element_011_sodium.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Sodium_Spectra.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/0/0b/Sodium_Spectra.jpg',
       summary:
         'Sodium /ˈsoʊdiəm/ is a chemical element with symbol Na (from Ancient Greek Νάτριο) and atomic number 11. It is a soft, silver-white, highly reactive metal. In the Periodic table it is in column 1 (alkali metals), and shares with the other six elements in that column that it has a single electron in its outer shell, which it readily donates, creating a positively charged atom - a cation.',
       symbol: 'Na',
@@ -502,7 +502,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_012_magnesium/element_012_magnesium_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_012_magnesium/element_012_magnesium.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Magnesium_Spectra.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/a/a0/Magnesium_Spectra.jpg',
       summary:
         'Magnesium is a chemical element with symbol Mg and atomic number 12. It is a shiny gray solid which bears a close physical resemblance to the other five elements in the second column (Group 2, or alkaline earth metals) of the periodic table:they each have the same electron configuration in their outer electron shell producing a similar crystal structure. Magnesium is the ninth most abundant element in the universe.',
       symbol: 'Mg',
@@ -593,7 +593,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_014_silicon/element_014_silicon_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_014_silicon/element_014_silicon.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Silicon_Spectra.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/0/0b/Silicon_Spectra.jpg',
       summary:
         "Silicon is a chemical element with symbol Si and atomic number 14. It is a tetravalent metalloid, more reactive than germanium, the metalloid directly below it in the table. Controversy about silicon's character dates to its discovery.",
       symbol: 'Si',
@@ -685,7 +685,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_016_sulfur/element_016_sulfur_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_016_sulfur/element_016_sulfur.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Sulfur_Spectrum.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/b/b4/Sulfur_Spectrum.jpg',
       summary:
         'Sulfur or sulphur (see spelling differences) is a chemical element with symbol S and atomic number 16. It is an abundant, multivalent non-metal. Under normal conditions, sulfur atoms form cyclic octatomic molecules with chemical formula S8.',
       symbol: 'S',
@@ -731,7 +731,8 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_017_chlorine/element_017_chlorine_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_017_chlorine/element_017_chlorine.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Chlorine_spectrum_visible.png',
+      spectral_img:
+        'https://upload.wikimedia.org/wikipedia/commons/6/61/Chlorine_spectrum_visible.png',
       summary:
         'Chlorine is a chemical element with symbol Cl and atomic number 17. It also has a relative atomic mass of 35.5. Chlorine is in the halogen group (17) and is the second lightest halogen following fluorine.',
       symbol: 'Cl',
@@ -777,7 +778,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_018_argon/element_018_argon_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_018_argon/element_018_argon.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Argon_Spectrum.png',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/3/37/Argon_Spectrum.png',
       summary:
         "Argon is a chemical element with symbol Ar and atomic number 18. It is in group 18 of the periodic table and is a noble gas. Argon is the third most common gas in the Earth's atmosphere, at 0.934% (9,340 ppmv), making it over twice as abundant as the next most common atmospheric gas, water vapor (which averages about 4000 ppmv, but varies greatly), and 23 times as abundant as the next most common non-condensing atmospheric gas, carbon dioxide (400 ppmv), and more than 500 times as abundant as the next most common noble gas, neon (18 ppmv).",
       symbol: 'Ar',
@@ -823,7 +824,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_019_potassium/element_019_potassium_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_019_potassium/element_019_potassium.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Potassium_Spectrum.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/d/d0/Potassium_Spectrum.jpg',
       summary:
         'Potassium is a chemical element with symbol K (derived from Neo-Latin, kalium) and atomic number 19. It was first isolated from potash, the ashes of plants, from which its name is derived. In the Periodic table, potassium is one of seven elements in column (group) 1 (alkali metals):they all have a single valence electron in their outer electron shell, which they readily give up to create an atom with a positive charge - a cation, and combine with anions to form salts.',
       symbol: 'K',
@@ -869,7 +870,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_020_calcium/element_020_calcium_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_020_calcium/element_020_calcium.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Calcium_Spectrum.png',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/2/21/Calcium_Spectrum.png',
       summary:
         "Calcium is a chemical element with symbol Ca and atomic number 20. Calcium is a soft gray alkaline earth metal, fifth-most-abundant element by mass in the Earth's crust. The ion Ca2+ is also the fifth-most-abundant dissolved ion in seawater by both molarity and mass, after sodium, chloride, magnesium, and sulfate.",
       symbol: 'Ca',
@@ -1146,7 +1147,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_026_iron/element_026_iron_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_026_iron/element_026_iron.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Iron_Spectrum.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/6/6a/Iron_Spectrum.jpg',
       summary:
         "Iron is a chemical element with symbol Fe (from Latin:ferrum) and atomic number 26. It is a metal in the first transition series. It is by mass the most common element on Earth, forming much of Earth's outer and inner core.",
       symbol: 'Fe',
@@ -1597,7 +1598,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_036_krypton/element_036_krypton_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_036_krypton/element_036_krypton.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Krypton_Spectrum.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Krypton_Spectrum.jpg',
       summary:
         'Krypton (from Greek:κρυπτός kryptos "the hidden one") is a chemical element with symbol Kr and atomic number 36. It is a member of group 18 (noble gases) elements. A colorless, odorless, tasteless noble gas, krypton occurs in trace amounts in the atmosphere, is isolated by fractionally distilling liquefied air, and is often used with other rare gases in fluorescent lamps.',
       symbol: 'Kr',
@@ -2384,7 +2385,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_054_xenon/element_054_xenon_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_054_xenon/element_054_xenon.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Xenon_Spectrum.jpg',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/6/67/Xenon_Spectrum.jpg',
       summary:
         "Xenon is a chemical element with symbol Xe and atomic number 54. It is a colorless, dense, odorless noble gas, that occurs in the Earth's atmosphere in trace amounts. Although generally unreactive, xenon can undergo a few chemical reactions such as the formation of xenon hexafluoroplatinate, the first noble gas compound to be synthesized.",
       symbol: 'Xe',
@@ -3162,7 +3163,8 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_072_hafnium/element_072_hafnium_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_072_hafnium/element_072_hafnium.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Hafnium_spectrum_visible.png',
+      spectral_img:
+        'https://upload.wikimedia.org/wikipedia/commons/a/ac/Hafnium_spectrum_visible.png',
       summary:
         'Hafnium is a chemical element with symbol Hf and atomic number 72. A lustrous, silvery gray, tetravalent transition metal, hafnium chemically resembles zirconium and is found in zirconium minerals. Its existence was predicted by Dmitri Mendeleev in 1869, though it was not identified until 1923, making it the penultimate stable element to be discovered (rhenium was identified two years later).',
       symbol: 'Hf',
@@ -3205,7 +3207,8 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_073_tantalum/element_073_tantalum_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_073_tantalum/element_073_tantalum.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Tantalum_spectrum_visible.png',
+      spectral_img:
+        'https://upload.wikimedia.org/wikipedia/commons/a/a6/Tantalum_spectrum_visible.png',
       summary:
         'Tantalum is a chemical element with symbol Ta and atomic number 73. Previously known as tantalium, its name comes from Tantalus, an antihero from Greek mythology. Tantalum is a rare, hard, blue-gray, lustrous transition metal that is highly corrosion-resistant.',
       symbol: 'Ta',
@@ -3767,7 +3770,7 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_086_radon/element_086_radon_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_086_radon/element_086_radon.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Radon_spectrum.png',
+      spectral_img: 'https://upload.wikimedia.org/wikipedia/commons/0/0d/Radon_spectrum.png',
       summary:
         'Radon is a chemical element with symbol Rn and atomic number 86. It is a radioactive, colorless, odorless, tasteless noble gas, occurring naturally as a decay product of radium. Its most stable isotope, 222Rn, has a half-life of 3.8 days.',
       symbol: 'Rn',
@@ -4160,7 +4163,8 @@ export const ELEMENT_DATA: Elements = {
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_095_americium/element_095_americium_srp_th.png',
       bohr_model_3d:
         'https://storage.googleapis.com/search-ar-edu/periodic-table/element_095_americium/element_095_americium.glb',
-      spectral_img: 'https://en.wikipedia.org/wiki/File:Americium_spectrum_visible.png',
+      spectral_img:
+        'https://upload.wikimedia.org/wikipedia/commons/3/37/Americium_spectrum_visible.png',
       summary:
         'Americium is a radioactive transuranic chemical element with symbol Am and atomic number 95. This member of the actinide series is located in the periodic table under the lanthanide element europium, and thus by analogy was named after the Americas. Americium was first produced in 1944 by the group of Glenn T.Seaborg from Berkeley, California, at the metallurgical laboratory of University of Chicago.',
       symbol: 'Am',

--- a/tests/mat-table.spec.ts
+++ b/tests/mat-table.spec.ts
@@ -22,9 +22,9 @@ test.describe('Mat table tab', () => {
   });
 
   test('renders expected default columns and footer summary', async ({ page }) => {
-    await expect(page.locator('th.mat-column-name')).toContainText('name');
-    await expect(page.locator('th.mat-column-atomic_mass')).toContainText('atomic_mass');
-    await expect(page.locator('th.mat-column-symbol')).toContainText('symbol');
+    await expect(page.locator('th.mat-column-name')).toContainText('Name');
+    await expect(page.locator('th.mat-column-atomic_mass')).toContainText('Atomic Mass');
+    await expect(page.locator('th.mat-column-symbol')).toContainText('Symbol');
     await expect(page.locator('th[aria-label="row actions"]')).toBeAttached();
 
     await expect(page.locator('td.mat-column-name.mat-mdc-footer-cell')).toContainText(
@@ -112,7 +112,7 @@ test.describe('Mat table tab', () => {
   test('supports selecting displayed columns from the column chooser', async ({ page }) => {
     await page.locator('[data-testid="column-chooser-trigger"]').click();
     const atomicMassCheckbox = page.locator('.cdk-overlay-container mat-checkbox', {
-      hasText: 'atomic_mass',
+      hasText: 'Atomic Mass',
     });
     await expect(atomicMassCheckbox).toBeVisible();
     await atomicMassCheckbox.click();


### PR DESCRIPTION
# Pull Request

## Summary

Represents Mat Table columns as a typed `ColumnDefinition` object instead of bare
strings, adds richer rendering for image/link columns, and fixes broken spectral
images.

**1. Typed column model (refactor).** Introduces
`ColumnDefinition { name; displayName; isSortable; width }` and switches
`FULL_LIST_OF_COLUMNS`, `DEFAULT_COLUMNS`, and the `columnsToDisplay` signal from
`string[]` to `ColumnDefinition[]`.
- `displayName` drives human-friendly headers and column-chooser labels
  (e.g. `atomic_mass` → "Atomic Mass", `electron_configuration_semantic` →
  "Electron Configuration (Semantic)").
- `isSortable` controls whether a header gets `mat-sort-header`; image/link columns
  (`source`, `image`, `bohr_model_image`, `bohr_model_3d`, `spectral_img`) are
  non-sortable, everything else sortable.
- `width` is the starting column width. For now every column uses the existing
  default (`DEFAULT_COLUMN_WIDTH`), set explicitly per column so individual widths
  can be tuned later. Column widths and the resize logic now fall back to each
  column's own `width`.
- Row/footer definitions still receive column *name* strings (Material requires
  this), so `columnsToDisplayWithExpand` / `columnsToRender` continue to emit names.

**2. Special rendering for URL/3D columns (feature).**
- `bohr_model_image` and `spectral_img` now render as `NgOptimizedImage` thumbnails
  (reusing `.image-thumb`, `fill`) with descriptive `alt` text.
- `bohr_model_3d` renders as an external link (`target="_blank"
  rel="noopener noreferrer"`), grouped with the existing `source` link column.
- All three are nullable in `PeriodicElement`, so each is null-guarded and renders
  an empty cell when the value is missing.

**3. Fix broken spectral images (bug fix).** `spectral_img` values pointed at
Wikipedia **File: description pages** (`.../wiki/File:Hydrogen_Spectra.jpg`) — HTML
pages, not images — so they rendered broken. Rewrote all 21 non-null values to their
canonical direct image URLs (`upload.wikimedia.org/wikipedia/commons/...`), matching
the format already used by the working `image.url` field. URLs were resolved via the
MediaWiki `imageinfo` API and cross-checked against locally computed Commons paths.

Also includes a small revision to the pull request template.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that alters existing behavior)
- [x] Refactor or cleanup (no behavior change)
- [x] Tests (unit, scripts, or Playwright e2e)
- [ ] Build, CI, or tooling
- [ ] Dependency update
- [ ] Documentation or AI instructions

## Areas Touched

- [x] Angular app (`src/`)
- [x] End-to-end tests (`tests/`)
- [ ] Node scripts (`scripts/`)
- [x] CI or workflows (`.github/`)
- [ ] AI instructions (`AGENTS.md` and its generated copies)
- [ ] Dependencies (`package.json` / `package-lock.json`)

## Related Issues

N/A

## How to Verify

1. `npm ci`
2. `npm run start`, then open http://localhost:4200/
3. On the **Mat Table** tab, confirm headers use friendly names (e.g. "Atomic Mass",
   "Electron Configuration (Semantic)") and that the `Source` column has no sort
   arrow while text columns remain sortable.
4. Open the column chooser (filter icon) and enable **Bohr Model Image**,
   **Bohr Model 3D**, and **Spectral Image**.
5. Confirm **Bohr Model Image** and **Spectral Image** render as image thumbnails
   (previously the spectral images were broken), **Bohr Model 3D** renders as an
   external link, and elements without a value show an empty cell.
6. Confirm column resizing and the friendly labels in the chooser still work.

Validated locally with scoped commands: `npm run lint:angular`,
`npm run lint:playwright`, `npm run build`,
`npm run test:unit -- --include 'src/app/components/mat-table/**/*.spec.ts'`
(122 passed), and `npx playwright test mat-table.spec.ts --project=chromium`
(9 passed). Run the full `npm run lint` / `npm run test` before merging.

## Checklist

Mirror the CI pipeline in `.github/workflows/actions.yml` before requesting a review.

- [x] Edited `AGENTS.md` (not the generated copies), then ran `npm run sync:agent-instructions`; `npm run sync:agent-instructions:check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (unit, scripts, and Playwright e2e)
- [x] `npm run build` succeeds
- [x] Tests added or updated to cover new or changed behavior
- [x] UI changes meet accessibility requirements (AXE clean, WCAG AA)
- [x] Documentation updated where applicable