### PR TITLE
Add Select All to column picker and adjust widths

### DIFF
--- a/src/app/components/mat-table/column-select/column-select.html
+++ b/src/app/components/mat-table/column-select/column-select.html
@@ -1,12 +1,23 @@
 <mat-card class="example-card" appearance="outlined">
   <mat-card-content class="card-content">
-    @for (column of fullListOfColumns(); track column.name) {
-      <mat-checkbox
-        [checked]="isColumnDisplayed(column)"
-        (change)="setColumnsToDisplay($event, column)"
-      >
-        {{ column.displayName }}
-      </mat-checkbox>
-    }
+    <mat-checkbox
+      [checked]="allColumnsSelected()"
+      [indeterminate]="partiallyComplete()"
+      (change)="setAllColumnsToDisplay($event.checked)"
+    >
+      Select All
+    </mat-checkbox>
+    <ul>
+      @for (column of fullListOfColumns(); track column.name) {
+        <li>
+          <mat-checkbox
+            [checked]="isColumnDisplayed(column)"
+            (change)="setColumnsToDisplay($event, column)"
+          >
+            {{ column.displayName }}
+          </mat-checkbox>
+        </li>
+      }
+    </ul>
   </mat-card-content>
 </mat-card>

--- a/src/app/components/mat-table/column-select/column-select.scss
+++ b/src/app/components/mat-table/column-select/column-select.scss
@@ -3,7 +3,6 @@
   flex: auto;
   flex-direction: column;
   min-width: 100px;
-  text-align: center;
   padding: 10px;
   margin: 0;
 }
@@ -15,4 +14,8 @@
   align-items: flex-start;
   overflow: auto;
   max-height: 300px;
+}
+
+ul {
+  list-style-type: none;
 }

--- a/src/app/components/mat-table/column-select/column-select.spec.ts
+++ b/src/app/components/mat-table/column-select/column-select.spec.ts
@@ -117,13 +117,13 @@ describe('ColumnSelect', () => {
     });
 
     it('renders one checkbox per available column', () => {
-      const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
+      const checkboxes = fixture.debugElement.queryAll(By.css('li mat-checkbox'));
       expect(checkboxes).toHaveLength(mockColumns.length);
     });
 
     it('renders the human-friendly display name for each column', () => {
       const labels = fixture.debugElement
-        .queryAll(By.css('mat-checkbox'))
+        .queryAll(By.css('li mat-checkbox'))
         .map((checkbox) => (checkbox.nativeElement as HTMLElement).textContent?.trim());
 
       expect(labels).toEqual(mockColumns.map((column) => column.displayName));
@@ -131,7 +131,7 @@ describe('ColumnSelect', () => {
 
     it('reflects selected columns in checkbox checked states', () => {
       const checkboxInstances = fixture.debugElement
-        .queryAll(By.css('mat-checkbox'))
+        .queryAll(By.css('li mat-checkbox'))
         .map((checkbox) => checkbox.componentInstance as MatCheckbox);
 
       expect(checkboxInstances.map((checkbox) => checkbox.checked)).toEqual([
@@ -143,7 +143,7 @@ describe('ColumnSelect', () => {
     });
 
     it('updates columnsToDisplay when a checkbox change event is emitted', () => {
-      const checkboxes = fixture.debugElement.queryAll(By.css('mat-checkbox'));
+      const checkboxes = fixture.debugElement.queryAll(By.css('li mat-checkbox'));
 
       checkboxes[2].triggerEventHandler('change', { checked: false });
       fixture.detectChanges();
@@ -152,6 +152,93 @@ describe('ColumnSelect', () => {
       checkboxes[1].triggerEventHandler('change', { checked: true });
       fixture.detectChanges();
       expect(component.columnsToDisplay()).toEqual([nameColumn, atomicMassColumn]);
+    });
+  });
+
+  describe('Select All Checkbox', () => {
+    function selectAllCheckbox() {
+      return fixture.debugElement.query(By.css('.card-content > mat-checkbox'));
+    }
+
+    beforeEach(() => {
+      TestBed.runInInjectionContext(() => {
+        fixture.componentRef.setInput('fullListOfColumns', mockColumns);
+        fixture.componentRef.setInput('columnsToDisplay', [nameColumn, symbolColumn]);
+      });
+      fixture.detectChanges();
+    });
+
+    it('is indeterminate when only some columns are displayed', () => {
+      expect(component.allColumnsSelected()).toBe(false);
+      expect(component.partiallyComplete()).toBe(true);
+
+      const selectAll = selectAllCheckbox().componentInstance as MatCheckbox;
+      expect(selectAll.checked).toBe(false);
+      expect(selectAll.indeterminate).toBe(true);
+    });
+
+    it('is checked and not indeterminate when every column is displayed', () => {
+      component.columnsToDisplay.set([...mockColumns]);
+      fixture.detectChanges();
+
+      expect(component.allColumnsSelected()).toBe(true);
+      expect(component.partiallyComplete()).toBe(false);
+
+      const selectAll = selectAllCheckbox().componentInstance as MatCheckbox;
+      expect(selectAll.checked).toBe(true);
+      expect(selectAll.indeterminate).toBe(false);
+    });
+
+    it('is unchecked and not indeterminate when no full-list column is displayed', () => {
+      component.columnsToDisplay.set([]);
+      fixture.detectChanges();
+
+      expect(component.allColumnsSelected()).toBe(false);
+      expect(component.partiallyComplete()).toBe(false);
+
+      const selectAll = selectAllCheckbox().componentInstance as MatCheckbox;
+      expect(selectAll.checked).toBe(false);
+      expect(selectAll.indeterminate).toBe(false);
+    });
+
+    it('selects every column in full-list order when checked', () => {
+      component.setAllColumnsToDisplay(true);
+
+      expect(component.columnsToDisplay()).toEqual(mockColumns);
+    });
+
+    it('deselects every full-list column when unchecked', () => {
+      component.setAllColumnsToDisplay(false);
+
+      expect(component.columnsToDisplay()).toEqual([]);
+    });
+
+    it('keeps columns that are not part of the full list when selecting all', () => {
+      component.columnsToDisplay.set([sourceColumn]);
+
+      component.setAllColumnsToDisplay(true);
+
+      expect(component.columnsToDisplay()).toEqual([...mockColumns, sourceColumn]);
+    });
+
+    it('keeps columns that are not part of the full list when deselecting all', () => {
+      component.columnsToDisplay.set([nameColumn, sourceColumn, symbolColumn]);
+
+      component.setAllColumnsToDisplay(false);
+
+      expect(component.columnsToDisplay()).toEqual([sourceColumn]);
+    });
+
+    it('toggles all columns through the checkbox change event', () => {
+      const selectAll = selectAllCheckbox();
+
+      selectAll.triggerEventHandler('change', { checked: true });
+      fixture.detectChanges();
+      expect(component.columnsToDisplay()).toEqual(mockColumns);
+
+      selectAll.triggerEventHandler('change', { checked: false });
+      fixture.detectChanges();
+      expect(component.columnsToDisplay()).toEqual([]);
     });
   });
 });

--- a/src/app/components/mat-table/column-select/column-select.ts
+++ b/src/app/components/mat-table/column-select/column-select.ts
@@ -80,22 +80,18 @@ export class ColumnSelect {
 
   private sortByFullListOrder(columns: ColumnDefinition[]): ColumnDefinition[] {
     const fullListOfColumns = this.fullListOfColumns();
+    const indexByName = new Map(fullListOfColumns.map((column, index) => [column.name, index]));
+    const orderOf = (name: string) => indexByName.get(name) ?? Number.POSITIVE_INFINITY;
 
     return [...columns].sort((a, b) => {
-      const columnAIndex = fullListOfColumns.findIndex((current) => current.name === a.name);
-      const columnBIndex = fullListOfColumns.findIndex((current) => current.name === b.name);
+      const orderA = orderOf(a.name);
+      const orderB = orderOf(b.name);
 
-      if (columnAIndex === -1 && columnBIndex === -1) {
+      if (orderA === orderB) {
         return 0;
       }
-      if (columnAIndex === -1) {
-        return 1;
-      }
-      if (columnBIndex === -1) {
-        return -1;
-      }
 
-      return columnAIndex - columnBIndex;
+      return orderA - orderB;
     });
   }
 }

--- a/src/app/components/mat-table/column-select/column-select.ts
+++ b/src/app/components/mat-table/column-select/column-select.ts
@@ -1,4 +1,4 @@
-import { Component, input, model } from '@angular/core';
+import { Component, computed, input, model } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { ColumnDefinition } from '../../../interfaces/column-definition';
@@ -13,8 +13,29 @@ export class ColumnSelect {
   readonly fullListOfColumns = input.required<ColumnDefinition[]>();
   readonly columnsToDisplay = model.required<ColumnDefinition[]>();
 
+  private readonly displayedColumnNames = computed(
+    () => new Set(this.columnsToDisplay().map((column) => column.name)),
+  );
+
+  readonly allColumnsSelected = computed(() => {
+    const fullListOfColumns = this.fullListOfColumns();
+    const displayed = this.displayedColumnNames();
+
+    return (
+      fullListOfColumns.length > 0 &&
+      fullListOfColumns.every((column) => displayed.has(column.name))
+    );
+  });
+
+  readonly partiallyComplete = computed(() => {
+    const displayed = this.displayedColumnNames();
+    const someSelected = this.fullListOfColumns().some((column) => displayed.has(column.name));
+
+    return someSelected && !this.allColumnsSelected();
+  });
+
   isColumnDisplayed(column: ColumnDefinition): boolean {
-    return this.columnsToDisplay().some((displayed) => displayed.name === column.name);
+    return this.displayedColumnNames().has(column.name);
   }
 
   setColumnsToDisplay(event: MatCheckboxChange, column: ColumnDefinition) {
@@ -24,30 +45,57 @@ export class ColumnSelect {
           return currentColumns;
         }
 
-        const fullListOfColumns = this.fullListOfColumns();
-
-        return [...currentColumns, column].sort((a, b) => {
-          const columnAIndex = fullListOfColumns.findIndex((current) => current.name === a.name);
-          const columnBIndex = fullListOfColumns.findIndex((current) => current.name === b.name);
-
-          if (columnAIndex === -1 && columnBIndex === -1) {
-            return 0;
-          }
-          if (columnAIndex === -1) {
-            return 1;
-          }
-          if (columnBIndex === -1) {
-            return -1;
-          }
-
-          return columnAIndex - columnBIndex;
-        });
+        return this.sortByFullListOrder([...currentColumns, column]);
       });
       return;
     }
 
-    this.columnsToDisplay.update((currentColumns) => {
-      return currentColumns.filter((currentColumn) => currentColumn.name !== column.name);
+    this.columnsToDisplay.update((currentColumns) =>
+      currentColumns.filter((currentColumn) => currentColumn.name !== column.name),
+    );
+  }
+
+  setAllColumnsToDisplay(checked: boolean) {
+    const fullListOfColumns = this.fullListOfColumns();
+
+    if (checked) {
+      this.columnsToDisplay.update((currentColumns) => {
+        const displayed = new Set(currentColumns.map((column) => column.name));
+        const columnsToAdd = fullListOfColumns.filter((column) => !displayed.has(column.name));
+
+        if (columnsToAdd.length === 0) {
+          return currentColumns;
+        }
+
+        return this.sortByFullListOrder([...currentColumns, ...columnsToAdd]);
+      });
+      return;
+    }
+
+    const fullListColumnNames = new Set(fullListOfColumns.map((column) => column.name));
+    this.columnsToDisplay.update((currentColumns) =>
+      currentColumns.filter((column) => !fullListColumnNames.has(column.name)),
+    );
+  }
+
+  private sortByFullListOrder(columns: ColumnDefinition[]): ColumnDefinition[] {
+    const fullListOfColumns = this.fullListOfColumns();
+
+    return [...columns].sort((a, b) => {
+      const columnAIndex = fullListOfColumns.findIndex((current) => current.name === a.name);
+      const columnBIndex = fullListOfColumns.findIndex((current) => current.name === b.name);
+
+      if (columnAIndex === -1 && columnBIndex === -1) {
+        return 0;
+      }
+      if (columnAIndex === -1) {
+        return 1;
+      }
+      if (columnBIndex === -1) {
+        return -1;
+      }
+
+      return columnAIndex - columnBIndex;
     });
   }
 }

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -164,7 +164,8 @@ describe('MatTable', () => {
     });
 
     it('computes tableWidth from default widths plus the expand column', () => {
-      const expected = DEFAULT_COLUMNS.length * DEFAULT_COLUMN_WIDTH + EXPAND_COLUMN_WIDTH;
+      const expected =
+        DEFAULT_COLUMNS.reduce((total, column) => total + column.width, 0) + EXPAND_COLUMN_WIDTH;
       expect(component.tableWidth()).toBe(expected);
     });
 

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -31,7 +31,7 @@ export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
     width: DEFAULT_COLUMN_WIDTH,
   },
   { name: 'boil', displayName: 'Boiling Point', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'category', displayName: 'Category', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
+  { name: 'category', displayName: 'Category', isSortable: true, width: 200 },
   { name: 'density', displayName: 'Density', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
   {
     name: 'discovered_by',
@@ -75,13 +75,13 @@ export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
     name: 'electron_configuration',
     displayName: 'Electron Configuration',
     isSortable: true,
-    width: DEFAULT_COLUMN_WIDTH,
+    width: 200,
   },
   {
     name: 'electron_configuration_semantic',
     displayName: 'Electron Configuration (Semantic)',
     isSortable: true,
-    width: DEFAULT_COLUMN_WIDTH,
+    width: 300,
   },
   {
     name: 'electron_affinity',
@@ -93,7 +93,7 @@ export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
     name: 'electronegativity_pauling',
     displayName: 'Electronegativity (Pauling)',
     isSortable: true,
-    width: DEFAULT_COLUMN_WIDTH,
+    width: 250,
   },
   {
     name: 'ionization_energies',
@@ -125,7 +125,7 @@ const SOURCE_COLUMN: ColumnDefinition = {
   name: 'source',
   displayName: 'Source',
   isSortable: false,
-  width: DEFAULT_COLUMN_WIDTH,
+  width: 300,
 };
 
 export const DEFAULT_COLUMNS: ColumnDefinition[] = [

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -19,8 +19,9 @@ export const DEFAULT_COLUMN_WIDTH = 150;
 export const EXPAND_COLUMN_WIDTH = 56;
 export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
 
-// Every column starts at DEFAULT_COLUMN_WIDTH for now; the explicit per-column
-// `width` makes it easy to tune each one to an appropriate value later.
+// Most columns use DEFAULT_COLUMN_WIDTH, with a few tuned to wider values where
+// their content warrants it. The explicit per-column `width` makes it easy to
+// adjust any column to an appropriate value.
 export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
   { name: 'name', displayName: 'Name', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
   { name: 'appearance', displayName: 'Appearance', isSortable: true, width: DEFAULT_COLUMN_WIDTH },


### PR DESCRIPTION
# Pull Request

## Summary

Enhances the mat-table column selector with a top-level Select All checkbox, including checked/indeterminate states and logic to preserve full-list ordering while retaining non-full-list columns when toggling. Updates unit tests and markup/styles for the new structure, and increases widths for several long-content columns (plus Source) to improve table readability.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that alters existing behavior)
- [ ] Refactor or cleanup (no behavior change)
- [ ] Tests (unit, scripts, or Playwright e2e)
- [ ] Build, CI, or tooling
- [ ] Dependency update
- [ ] Documentation or AI instructions

## Areas Touched

- [x] Angular app (`src/`)
- [ ] End-to-end tests (`tests/`)
- [ ] Node scripts (`scripts/`)
- [ ] CI or workflows (`.github/`)
- [ ] AI instructions (`AGENTS.md` and its generated copies)
- [ ] Dependencies (`package.json` / `package-lock.json`)

## Related Issues

N/A

## How to Verify

Steps a reviewer can follow to confirm the change behaves as expected.

1. `npm ci`
2. `npm run start`, then open http://localhost:4200/
3. Open column select menu and select all or deselect all. Notice how it starts in an indeterminate state

## Checklist

Mirror the CI pipeline in `.github/workflows/actions.yml` before requesting a review.

- [ ] Edited `AGENTS.md` (not the generated copies), then ran `npm run sync:agent-instructions`; `npm run sync:agent-instructions:check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (unit, scripts, and Playwright e2e)
- [x] `npm run build` succeeds
- [x] Tests added or updated to cover new or changed behavior
- [x] UI changes meet accessibility requirements (AXE clean, WCAG AA)
- [ ] Documentation updated where applicable
