### PR TITLE
Column def

### DIFF
--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -7,7 +7,6 @@ import { FilterState } from '../../interfaces/filter-state';
 import { ColumnSelect } from './column-select/column-select';
 import {
   DEFAULT_COLUMNS,
-  DEFAULT_COLUMN_WIDTH,
   EXPAND_COLUMN_WIDTH,
   FULL_LIST_OF_COLUMNS,
   MatTable,
@@ -143,9 +142,9 @@ describe('MatTable', () => {
   });
 
   describe('Column Resizing', () => {
-    it('returns the default width for columns without an override', () => {
+    it('returns the defined width for columns without an override', () => {
       const [nameColumn] = columns('name');
-      expect(component.columnWidth(nameColumn)).toBe(DEFAULT_COLUMN_WIDTH);
+      expect(component.columnWidth(nameColumn)).toBe(nameColumn.width);
     });
 
     it('stores and returns an explicit width for a column', () => {
@@ -170,14 +169,18 @@ describe('MatTable', () => {
     });
 
     it('reflects a resized column in tableWidth', () => {
+      const [nameColumn] = columns('name');
       const before = component.tableWidth();
-      component.setColumnWidth('name', DEFAULT_COLUMN_WIDTH + 100);
+      component.setColumnWidth('name', nameColumn.width + 100);
       expect(component.tableWidth()).toBe(before + 100);
     });
 
     it('recomputes tableWidth when displayed columns change', () => {
-      component.columnsToDisplay.set(columns('name', 'symbol'));
-      expect(component.tableWidth()).toBe(2 * DEFAULT_COLUMN_WIDTH + EXPAND_COLUMN_WIDTH);
+      const displayed = columns('name', 'symbol');
+      component.columnsToDisplay.set(displayed);
+      const expected =
+        displayed.reduce((total, column) => total + column.width, 0) + EXPAND_COLUMN_WIDTH;
+      expect(component.tableWidth()).toBe(expected);
     });
 
     it('exposes the expand column width constant', () => {

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -6,26 +6,18 @@ import { ColumnDefinition } from '../../interfaces/column-definition';
 import { FilterState } from '../../interfaces/filter-state';
 import { ColumnSelect } from './column-select/column-select';
 import {
+  ATOMIC_MASS_COLUMN,
+  BOHR_MODEL_3D_COLUMN,
+  BOHR_MODEL_IMAGE_COLUMN,
   DEFAULT_COLUMNS,
   EXPAND_COLUMN_WIDTH,
   FULL_LIST_OF_COLUMNS,
   MatTable,
+  NAME_COLUMN,
   RESIZE_SPACER_COLUMN,
+  SPECTRAL_IMG_COLUMN,
+  SYMBOL_COLUMN,
 } from './mat-table';
-
-const COLUMN_BY_NAME = new Map<string, ColumnDefinition>(
-  [...FULL_LIST_OF_COLUMNS, ...DEFAULT_COLUMNS].map((column) => [column.name, column]),
-);
-
-function columns(...names: string[]): ColumnDefinition[] {
-  return names.map((name) => {
-    const column = COLUMN_BY_NAME.get(name);
-    if (!column) {
-      throw new Error(`Unknown column in test helper: ${name}`);
-    }
-    return column;
-  });
-}
 
 function columnNames(definitions: ColumnDefinition[]): string[] {
   return definitions.map((column) => column.name);
@@ -107,13 +99,13 @@ describe('MatTable', () => {
 
   describe('Column Management', () => {
     it('updates columnsToDisplay signal', () => {
-      const newColumns = columns('name', 'symbol');
+      const newColumns = [NAME_COLUMN, SYMBOL_COLUMN];
       component.columnsToDisplay.set(newColumns);
       expect(component.columnsToDisplay()).toEqual(newColumns);
     });
 
     it('columnsToDisplayWithExpand updates when columnsToDisplay changes', () => {
-      const newColumns = columns('name', 'symbol', 'atomic_mass');
+      const newColumns = [NAME_COLUMN, SYMBOL_COLUMN, ATOMIC_MASS_COLUMN];
       component.columnsToDisplay.set(newColumns);
       expect(component.columnsToDisplayWithExpand()).toEqual([
         ...columnNames(newColumns),
@@ -133,7 +125,7 @@ describe('MatTable', () => {
     });
 
     it('can reset displayed columns to DEFAULT_COLUMNS', () => {
-      component.columnsToDisplay.set(columns('name', 'symbol'));
+      component.columnsToDisplay.set([NAME_COLUMN, SYMBOL_COLUMN]);
       expect(component.columnsToDisplay()).not.toEqual(DEFAULT_COLUMNS);
 
       component.columnsToDisplay.set(DEFAULT_COLUMNS);
@@ -143,23 +135,20 @@ describe('MatTable', () => {
 
   describe('Column Resizing', () => {
     it('returns the defined width for columns without an override', () => {
-      const [nameColumn] = columns('name');
-      expect(component.columnWidth(nameColumn)).toBe(nameColumn.width);
+      expect(component.columnWidth(NAME_COLUMN)).toBe(NAME_COLUMN.width);
     });
 
     it('stores and returns an explicit width for a column', () => {
-      const [nameColumn] = columns('name');
       component.setColumnWidth('name', 240);
-      expect(component.columnWidth(nameColumn)).toBe(240);
+      expect(component.columnWidth(NAME_COLUMN)).toBe(240);
     });
 
     it('preserves widths of other columns when one is resized', () => {
-      const [nameColumn, symbolColumn] = columns('name', 'symbol');
       component.setColumnWidth('name', 240);
       component.setColumnWidth('symbol', 90);
 
-      expect(component.columnWidth(nameColumn)).toBe(240);
-      expect(component.columnWidth(symbolColumn)).toBe(90);
+      expect(component.columnWidth(NAME_COLUMN)).toBe(240);
+      expect(component.columnWidth(SYMBOL_COLUMN)).toBe(90);
     });
 
     it('computes tableWidth from default widths plus the expand column', () => {
@@ -169,14 +158,13 @@ describe('MatTable', () => {
     });
 
     it('reflects a resized column in tableWidth', () => {
-      const [nameColumn] = columns('name');
       const before = component.tableWidth();
-      component.setColumnWidth('name', nameColumn.width + 100);
+      component.setColumnWidth('name', NAME_COLUMN.width + 100);
       expect(component.tableWidth()).toBe(before + 100);
     });
 
     it('recomputes tableWidth when displayed columns change', () => {
-      const displayed = columns('name', 'symbol');
+      const displayed = [NAME_COLUMN, SYMBOL_COLUMN];
       component.columnsToDisplay.set(displayed);
       const expected =
         displayed.reduce((total, column) => total + column.width, 0) + EXPAND_COLUMN_WIDTH;
@@ -446,7 +434,7 @@ describe('MatTable', () => {
 
       const columnSelect = fixture.debugElement.query(By.directive(ColumnSelect));
       expect(columnSelect).toBeTruthy();
-      const newColumns = columns('name', 'symbol', 'atomic_mass');
+      const newColumns = [NAME_COLUMN, SYMBOL_COLUMN, ATOMIC_MASS_COLUMN];
 
       columnSelect.triggerEventHandler('columnsToDisplayChange', newColumns);
       fixture.detectChanges();
@@ -462,9 +450,12 @@ describe('MatTable', () => {
     }
 
     beforeEach(() => {
-      component.columnsToDisplay.set(
-        columns('name', 'bohr_model_image', 'bohr_model_3d', 'spectral_img'),
-      );
+      component.columnsToDisplay.set([
+        NAME_COLUMN,
+        BOHR_MODEL_IMAGE_COLUMN,
+        BOHR_MODEL_3D_COLUMN,
+        SPECTRAL_IMG_COLUMN,
+      ]);
       fixture.detectChanges();
     });
 
@@ -725,7 +716,7 @@ describe('MatTable', () => {
       const initialHeaders = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
       const initialCount = initialHeaders.length;
 
-      component.columnsToDisplay.set(columns('name', 'symbol'));
+      component.columnsToDisplay.set([NAME_COLUMN, SYMBOL_COLUMN]);
       fixture.detectChanges();
 
       const updatedHeaders = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
@@ -734,7 +725,7 @@ describe('MatTable', () => {
     });
 
     it('expandedDetail row maintains proper colspan after column change', () => {
-      component.columnsToDisplay.set(columns('name', 'symbol'));
+      component.columnsToDisplay.set([NAME_COLUMN, SYMBOL_COLUMN]);
       fixture.detectChanges();
 
       // Find the detail row cell with the example-element-detail-wrapper
@@ -765,9 +756,9 @@ describe('MatTable', () => {
 
     it('handles rapid column changes', () => {
       expect(() => {
-        component.columnsToDisplay.set(columns('name'));
-        component.columnsToDisplay.set(columns('symbol'));
-        component.columnsToDisplay.set(columns('atomic_mass'));
+        component.columnsToDisplay.set([NAME_COLUMN]);
+        component.columnsToDisplay.set([SYMBOL_COLUMN]);
+        component.columnsToDisplay.set([ATOMIC_MASS_COLUMN]);
         component.columnsToDisplay.set(DEFAULT_COLUMNS);
       }).not.toThrow();
 

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -22,103 +22,222 @@ export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
 // Most columns use DEFAULT_COLUMN_WIDTH, with a few tuned to wider values where
 // their content warrants it. The explicit per-column `width` makes it easy to
 // adjust any column to an appropriate value.
-export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
-  { name: 'name', displayName: 'Name', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'appearance', displayName: 'Appearance', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  {
-    name: 'atomic_mass',
-    displayName: 'Atomic Mass',
-    isSortable: true,
-    width: DEFAULT_COLUMN_WIDTH,
-  },
-  { name: 'boil', displayName: 'Boiling Point', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'category', displayName: 'Category', isSortable: true, width: 200 },
-  { name: 'density', displayName: 'Density', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  {
-    name: 'discovered_by',
-    displayName: 'Discovered By',
-    isSortable: true,
-    width: DEFAULT_COLUMN_WIDTH,
-  },
-  { name: 'melt', displayName: 'Melting Point', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'molar_heat', displayName: 'Molar Heat', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'named_by', displayName: 'Named By', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'number', displayName: 'Number', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'period', displayName: 'Period', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'group', displayName: 'Group', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'phase', displayName: 'Phase', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  {
-    name: 'bohr_model_image',
-    displayName: 'Bohr Model Image',
-    isSortable: false,
-    width: DEFAULT_COLUMN_WIDTH,
-  },
-  {
-    name: 'bohr_model_3d',
-    displayName: 'Bohr Model 3D',
-    isSortable: false,
-    width: DEFAULT_COLUMN_WIDTH,
-  },
-  {
-    name: 'spectral_img',
-    displayName: 'Spectral Image',
-    isSortable: false,
-    width: DEFAULT_COLUMN_WIDTH,
-  },
-  { name: 'summary', displayName: 'Summary', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'symbol', displayName: 'Symbol', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'xpos', displayName: 'X Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'ypos', displayName: 'Y Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'wxpos', displayName: 'Wide X Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'wypos', displayName: 'Wide Y Position', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'shells', displayName: 'Shells', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-  {
-    name: 'electron_configuration',
-    displayName: 'Electron Configuration',
-    isSortable: true,
-    width: 200,
-  },
-  {
-    name: 'electron_configuration_semantic',
-    displayName: 'Electron Configuration (Semantic)',
-    isSortable: true,
-    width: 300,
-  },
-  {
-    name: 'electron_affinity',
-    displayName: 'Electron Affinity',
-    isSortable: true,
-    width: DEFAULT_COLUMN_WIDTH,
-  },
-  {
-    name: 'electronegativity_pauling',
-    displayName: 'Electronegativity (Pauling)',
-    isSortable: true,
-    width: 250,
-  },
-  {
-    name: 'ionization_energies',
-    displayName: 'Ionization Energies',
-    isSortable: true,
-    width: DEFAULT_COLUMN_WIDTH,
-  },
-  { name: 'image', displayName: 'Image', isSortable: false, width: DEFAULT_COLUMN_WIDTH },
-  { name: 'block', displayName: 'Block', isSortable: true, width: DEFAULT_COLUMN_WIDTH },
-];
+const NAME_COLUMN: ColumnDefinition = {
+  name: 'name',
+  displayName: 'Name',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
 
-const COLUMN_DEFINITIONS_BY_NAME = new Map<string, ColumnDefinition>(
-  FULL_LIST_OF_COLUMNS.map((column) => [column.name, column]),
-);
+const APPEARANCE_COLUMN: ColumnDefinition = {
+  name: 'appearance',
+  displayName: 'Appearance',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
 
-function requireColumn(name: string): ColumnDefinition {
-  const column = COLUMN_DEFINITIONS_BY_NAME.get(name);
+const ATOMIC_MASS_COLUMN: ColumnDefinition = {
+  name: 'atomic_mass',
+  displayName: 'Atomic Mass',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
 
-  if (!column) {
-    throw new Error(`Unknown column definition: ${name}`);
-  }
+const BOIL_COLUMN: ColumnDefinition = {
+  name: 'boil',
+  displayName: 'Boiling Point',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
 
-  return column;
-}
+const CATEGORY_COLUMN: ColumnDefinition = {
+  name: 'category',
+  displayName: 'Category',
+  isSortable: true,
+  width: 200,
+};
+
+const DENSITY_COLUMN: ColumnDefinition = {
+  name: 'density',
+  displayName: 'Density',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const DISCOVERED_BY_COLUMN: ColumnDefinition = {
+  name: 'discovered_by',
+  displayName: 'Discovered By',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const MELT_COLUMN: ColumnDefinition = {
+  name: 'melt',
+  displayName: 'Melting Point',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const MOLAR_HEAT_COLUMN: ColumnDefinition = {
+  name: 'molar_heat',
+  displayName: 'Molar Heat',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const NAMED_BY_COLUMN: ColumnDefinition = {
+  name: 'named_by',
+  displayName: 'Named By',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const NUMBER_COLUMN: ColumnDefinition = {
+  name: 'number',
+  displayName: 'Number',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const PERIOD_COLUMN: ColumnDefinition = {
+  name: 'period',
+  displayName: 'Period',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const GROUP_COLUMN: ColumnDefinition = {
+  name: 'group',
+  displayName: 'Group',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const PHASE_COLUMN: ColumnDefinition = {
+  name: 'phase',
+  displayName: 'Phase',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const BOHR_MODEL_IMAGE_COLUMN: ColumnDefinition = {
+  name: 'bohr_model_image',
+  displayName: 'Bohr Model Image',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const BOHR_MODEL_3D_COLUMN: ColumnDefinition = {
+  name: 'bohr_model_3d',
+  displayName: 'Bohr Model 3D',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const SPECTRAL_IMG_COLUMN: ColumnDefinition = {
+  name: 'spectral_img',
+  displayName: 'Spectral Image',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const SUMMARY_COLUMN: ColumnDefinition = {
+  name: 'summary',
+  displayName: 'Summary',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const SYMBOL_COLUMN: ColumnDefinition = {
+  name: 'symbol',
+  displayName: 'Symbol',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const XPOS_COLUMN: ColumnDefinition = {
+  name: 'xpos',
+  displayName: 'X Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const YPOS_COLUMN: ColumnDefinition = {
+  name: 'ypos',
+  displayName: 'Y Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const WXPOS_COLUMN: ColumnDefinition = {
+  name: 'wxpos',
+  displayName: 'Wide X Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const WYPOS_COLUMN: ColumnDefinition = {
+  name: 'wypos',
+  displayName: 'Wide Y Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const SHELLS_COLUMN: ColumnDefinition = {
+  name: 'shells',
+  displayName: 'Shells',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const ELECTRON_CONFIGURATION_COLUMN: ColumnDefinition = {
+  name: 'electron_configuration',
+  displayName: 'Electron Configuration',
+  isSortable: true,
+  width: 200,
+};
+
+const ELECTRON_CONFIGURATION_SEMANTIC_COLUMN: ColumnDefinition = {
+  name: 'electron_configuration_semantic',
+  displayName: 'Electron Configuration (Semantic)',
+  isSortable: true,
+  width: 300,
+};
+
+const ELECTRON_AFFINITY_COLUMN: ColumnDefinition = {
+  name: 'electron_affinity',
+  displayName: 'Electron Affinity',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const ELECTRONEGATIVITY_PAULING_COLUMN: ColumnDefinition = {
+  name: 'electronegativity_pauling',
+  displayName: 'Electronegativity (Pauling)',
+  isSortable: true,
+  width: 250,
+};
+
+const IONIZATION_ENERGIES_COLUMN: ColumnDefinition = {
+  name: 'ionization_energies',
+  displayName: 'Ionization Energies',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const IMAGE_COLUMN: ColumnDefinition = {
+  name: 'image',
+  displayName: 'Image',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+const BLOCK_COLUMN: ColumnDefinition = {
+  name: 'block',
+  displayName: 'Block',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
 
 // `source` is shown by default but intentionally omitted from the column
 // chooser's full list, so it isn't part of FULL_LIST_OF_COLUMNS.
@@ -129,19 +248,53 @@ const SOURCE_COLUMN: ColumnDefinition = {
   width: 300,
 };
 
+export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
+  NAME_COLUMN,
+  APPEARANCE_COLUMN,
+  ATOMIC_MASS_COLUMN,
+  BOIL_COLUMN,
+  CATEGORY_COLUMN,
+  DENSITY_COLUMN,
+  DISCOVERED_BY_COLUMN,
+  MELT_COLUMN,
+  MOLAR_HEAT_COLUMN,
+  NAMED_BY_COLUMN,
+  NUMBER_COLUMN,
+  PERIOD_COLUMN,
+  GROUP_COLUMN,
+  PHASE_COLUMN,
+  BOHR_MODEL_IMAGE_COLUMN,
+  BOHR_MODEL_3D_COLUMN,
+  SPECTRAL_IMG_COLUMN,
+  SUMMARY_COLUMN,
+  SYMBOL_COLUMN,
+  XPOS_COLUMN,
+  YPOS_COLUMN,
+  WXPOS_COLUMN,
+  WYPOS_COLUMN,
+  SHELLS_COLUMN,
+  ELECTRON_CONFIGURATION_COLUMN,
+  ELECTRON_CONFIGURATION_SEMANTIC_COLUMN,
+  ELECTRON_AFFINITY_COLUMN,
+  ELECTRONEGATIVITY_PAULING_COLUMN,
+  IONIZATION_ENERGIES_COLUMN,
+  IMAGE_COLUMN,
+  BLOCK_COLUMN,
+];
+
 export const DEFAULT_COLUMNS: ColumnDefinition[] = [
-  requireColumn('name'),
-  requireColumn('atomic_mass'),
-  requireColumn('symbol'),
-  requireColumn('number'),
-  requireColumn('category'),
-  requireColumn('period'),
-  requireColumn('group'),
-  requireColumn('phase'),
+  NAME_COLUMN,
+  ATOMIC_MASS_COLUMN,
+  SYMBOL_COLUMN,
+  NUMBER_COLUMN,
+  CATEGORY_COLUMN,
+  PERIOD_COLUMN,
+  GROUP_COLUMN,
+  PHASE_COLUMN,
   SOURCE_COLUMN,
-  requireColumn('electron_configuration'),
-  requireColumn('electron_configuration_semantic'),
-  requireColumn('block'),
+  ELECTRON_CONFIGURATION_COLUMN,
+  ELECTRON_CONFIGURATION_SEMANTIC_COLUMN,
+  BLOCK_COLUMN,
 ];
 
 @Component({

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -22,217 +22,217 @@ export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
 // Most columns use DEFAULT_COLUMN_WIDTH, with a few tuned to wider values where
 // their content warrants it. The explicit per-column `width` makes it easy to
 // adjust any column to an appropriate value.
-const NAME_COLUMN: ColumnDefinition = {
+export const NAME_COLUMN: ColumnDefinition = {
   name: 'name',
   displayName: 'Name',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const APPEARANCE_COLUMN: ColumnDefinition = {
+export const APPEARANCE_COLUMN: ColumnDefinition = {
   name: 'appearance',
   displayName: 'Appearance',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const ATOMIC_MASS_COLUMN: ColumnDefinition = {
+export const ATOMIC_MASS_COLUMN: ColumnDefinition = {
   name: 'atomic_mass',
   displayName: 'Atomic Mass',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const BOIL_COLUMN: ColumnDefinition = {
+export const BOIL_COLUMN: ColumnDefinition = {
   name: 'boil',
   displayName: 'Boiling Point',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const CATEGORY_COLUMN: ColumnDefinition = {
+export const CATEGORY_COLUMN: ColumnDefinition = {
   name: 'category',
   displayName: 'Category',
   isSortable: true,
   width: 200,
 };
 
-const DENSITY_COLUMN: ColumnDefinition = {
+export const DENSITY_COLUMN: ColumnDefinition = {
   name: 'density',
   displayName: 'Density',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const DISCOVERED_BY_COLUMN: ColumnDefinition = {
+export const DISCOVERED_BY_COLUMN: ColumnDefinition = {
   name: 'discovered_by',
   displayName: 'Discovered By',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const MELT_COLUMN: ColumnDefinition = {
+export const MELT_COLUMN: ColumnDefinition = {
   name: 'melt',
   displayName: 'Melting Point',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const MOLAR_HEAT_COLUMN: ColumnDefinition = {
+export const MOLAR_HEAT_COLUMN: ColumnDefinition = {
   name: 'molar_heat',
   displayName: 'Molar Heat',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const NAMED_BY_COLUMN: ColumnDefinition = {
+export const NAMED_BY_COLUMN: ColumnDefinition = {
   name: 'named_by',
   displayName: 'Named By',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const NUMBER_COLUMN: ColumnDefinition = {
+export const NUMBER_COLUMN: ColumnDefinition = {
   name: 'number',
   displayName: 'Number',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const PERIOD_COLUMN: ColumnDefinition = {
+export const PERIOD_COLUMN: ColumnDefinition = {
   name: 'period',
   displayName: 'Period',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const GROUP_COLUMN: ColumnDefinition = {
+export const GROUP_COLUMN: ColumnDefinition = {
   name: 'group',
   displayName: 'Group',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const PHASE_COLUMN: ColumnDefinition = {
+export const PHASE_COLUMN: ColumnDefinition = {
   name: 'phase',
   displayName: 'Phase',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const BOHR_MODEL_IMAGE_COLUMN: ColumnDefinition = {
+export const BOHR_MODEL_IMAGE_COLUMN: ColumnDefinition = {
   name: 'bohr_model_image',
   displayName: 'Bohr Model Image',
   isSortable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const BOHR_MODEL_3D_COLUMN: ColumnDefinition = {
+export const BOHR_MODEL_3D_COLUMN: ColumnDefinition = {
   name: 'bohr_model_3d',
   displayName: 'Bohr Model 3D',
   isSortable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const SPECTRAL_IMG_COLUMN: ColumnDefinition = {
+export const SPECTRAL_IMG_COLUMN: ColumnDefinition = {
   name: 'spectral_img',
   displayName: 'Spectral Image',
   isSortable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const SUMMARY_COLUMN: ColumnDefinition = {
+export const SUMMARY_COLUMN: ColumnDefinition = {
   name: 'summary',
   displayName: 'Summary',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const SYMBOL_COLUMN: ColumnDefinition = {
+export const SYMBOL_COLUMN: ColumnDefinition = {
   name: 'symbol',
   displayName: 'Symbol',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const XPOS_COLUMN: ColumnDefinition = {
+export const XPOS_COLUMN: ColumnDefinition = {
   name: 'xpos',
   displayName: 'X Position',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const YPOS_COLUMN: ColumnDefinition = {
+export const YPOS_COLUMN: ColumnDefinition = {
   name: 'ypos',
   displayName: 'Y Position',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const WXPOS_COLUMN: ColumnDefinition = {
+export const WXPOS_COLUMN: ColumnDefinition = {
   name: 'wxpos',
   displayName: 'Wide X Position',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const WYPOS_COLUMN: ColumnDefinition = {
+export const WYPOS_COLUMN: ColumnDefinition = {
   name: 'wypos',
   displayName: 'Wide Y Position',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const SHELLS_COLUMN: ColumnDefinition = {
+export const SHELLS_COLUMN: ColumnDefinition = {
   name: 'shells',
   displayName: 'Shells',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const ELECTRON_CONFIGURATION_COLUMN: ColumnDefinition = {
+export const ELECTRON_CONFIGURATION_COLUMN: ColumnDefinition = {
   name: 'electron_configuration',
   displayName: 'Electron Configuration',
   isSortable: true,
   width: 200,
 };
 
-const ELECTRON_CONFIGURATION_SEMANTIC_COLUMN: ColumnDefinition = {
+export const ELECTRON_CONFIGURATION_SEMANTIC_COLUMN: ColumnDefinition = {
   name: 'electron_configuration_semantic',
   displayName: 'Electron Configuration (Semantic)',
   isSortable: true,
   width: 300,
 };
 
-const ELECTRON_AFFINITY_COLUMN: ColumnDefinition = {
+export const ELECTRON_AFFINITY_COLUMN: ColumnDefinition = {
   name: 'electron_affinity',
   displayName: 'Electron Affinity',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const ELECTRONEGATIVITY_PAULING_COLUMN: ColumnDefinition = {
+export const ELECTRONEGATIVITY_PAULING_COLUMN: ColumnDefinition = {
   name: 'electronegativity_pauling',
   displayName: 'Electronegativity (Pauling)',
   isSortable: true,
   width: 250,
 };
 
-const IONIZATION_ENERGIES_COLUMN: ColumnDefinition = {
+export const IONIZATION_ENERGIES_COLUMN: ColumnDefinition = {
   name: 'ionization_energies',
   displayName: 'Ionization Energies',
   isSortable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const IMAGE_COLUMN: ColumnDefinition = {
+export const IMAGE_COLUMN: ColumnDefinition = {
   name: 'image',
   displayName: 'Image',
   isSortable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
-const BLOCK_COLUMN: ColumnDefinition = {
+export const BLOCK_COLUMN: ColumnDefinition = {
   name: 'block',
   displayName: 'Block',
   isSortable: true,
@@ -241,7 +241,7 @@ const BLOCK_COLUMN: ColumnDefinition = {
 
 // `source` is shown by default but intentionally omitted from the column
 // chooser's full list, so it isn't part of FULL_LIST_OF_COLUMNS.
-const SOURCE_COLUMN: ColumnDefinition = {
+export const SOURCE_COLUMN: ColumnDefinition = {
   name: 'source',
   displayName: 'Source',
   isSortable: false,


### PR DESCRIPTION
# Pull Request

## Summary

Extracted each table column into named `ColumnDefinition` constants and rebuilt `FULL_LIST_OF_COLUMNS`/`DEFAULT_COLUMNS` from those constants, replacing string-based lookup via `requireColumn`. Updated resizing and table-width specs to assert against each column’s defined width instead of assuming a single default width, making tests accurate for mixed-width columns.

Export all column definition constants from mat-table.ts so tests can import them directly, replacing the internal COLUMN_BY_NAME map and columns() helper with direct references to the exported constants.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that alters existing behavior)
- [x] Refactor or cleanup (no behavior change)
- [x] Tests (unit, scripts, or Playwright e2e)
- [ ] Build, CI, or tooling
- [ ] Dependency update
- [ ] Documentation or AI instructions

## Areas Touched

- [x] Angular app (`src/`)
- [ ] End-to-end tests (`tests/`)
- [ ] Node scripts (`scripts/`)
- [ ] CI or workflows (`.github/`)
- [ ] AI instructions (`AGENTS.md` and its generated copies)
- [ ] Dependencies (`package.json` / `package-lock.json`)

## Related Issues

N/A

## How to Verify

Steps a reviewer can follow to confirm the change behaves as expected.

1. `npm ci`
2. `npm run start`, then open http://localhost:4200/
3. Verify

For UI changes, attach before/after screenshots or a short recording.

## Checklist

Mirror the CI pipeline in `.github/workflows/actions.yml` before requesting a review.

- [ ] Edited `AGENTS.md` (not the generated copies), then ran `npm run sync:agent-instructions`; `npm run sync:agent-instructions:check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (unit, scripts, and Playwright e2e)
- [x] `npm run build` succeeds
- [x] Tests added or updated to cover new or changed behavior
- [ ] UI changes meet accessibility requirements (AXE clean, WCAG AA)
- [ ] Documentation updated where applicable
