### PR TITLE
Restrict row expansion to expand button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2215,9 +2215,9 @@
       "optional": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3918,19 +3918,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6791,9 +6791,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.395",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
-      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -8587,9 +8587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8906,9 +8906,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.1.tgz",
+      "integrity": "sha512-O81l1g31PlH55F7AChkGM3sdWZX+1KDLnhesJ/V9Ziug5nIOnEPaVb2jLWAo1TbCOSeZPeNbxX4v/ywTuKSn9A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11461,9 +11461,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12201,35 +12201,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -12243,9 +12243,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -13996,9 +13996,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.21",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
-      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14411,9 +14411,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -150,8 +150,6 @@
       *matRowDef="let element; columns: columnsToRender()"
       class="example-element-row"
       [class.example-expanded-row]="isExpanded(element)"
-      (click)="toggleExpanded($event, element)"
-      (keydown)="toggleExpanded($event, element)"
     ></tr>
     <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="example-detail-row"></tr>
     <tr mat-footer-row *matFooterRowDef="columnsToRender(); sticky: true"></tr>

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -54,13 +54,6 @@ describe('MatTable', () => {
       expect(component.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
     });
 
-    it('creates columnsToDisplayWithExpand by appending expand column', () => {
-      expect(component.columnsToDisplayWithExpand()).toEqual([
-        ...columnNames(DEFAULT_COLUMNS),
-        'expand',
-      ]);
-    });
-
     it('creates columnsToRender by appending the expand and spacer columns', () => {
       expect(component.columnsToRender()).toEqual([
         ...columnNames(DEFAULT_COLUMNS),
@@ -104,19 +97,9 @@ describe('MatTable', () => {
       expect(component.columnsToDisplay()).toEqual(newColumns);
     });
 
-    it('columnsToDisplayWithExpand updates when columnsToDisplay changes', () => {
-      const newColumns = [NAME_COLUMN, SYMBOL_COLUMN, ATOMIC_MASS_COLUMN];
-      component.columnsToDisplay.set(newColumns);
-      expect(component.columnsToDisplayWithExpand()).toEqual([
-        ...columnNames(newColumns),
-        'expand',
-      ]);
-    });
-
     it('handles empty array of displayed columns', () => {
       component.columnsToDisplay.set([]);
       expect(component.columnsToDisplay()).toEqual([]);
-      expect(component.columnsToDisplayWithExpand()).toEqual(['expand']);
     });
 
     it('can set all columns from fullListOfColumns', () => {
@@ -590,19 +573,6 @@ describe('MatTable', () => {
       const rows = fixture.debugElement.queryAll(By.css('tr.example-element-row'));
       // Table has pagination with default page size of 25
       expect(rows.length).toBe(component.paginator()?.pageSize ?? 25);
-    });
-
-    it('toggles expand when clicking on a row', () => {
-      const element = component.dataSource.data[0];
-      const row = fixture.debugElement.query(By.css('tr.example-element-row'));
-
-      row.triggerEventHandler('click', new MouseEvent('click'));
-      fixture.detectChanges();
-      expect(component.isExpanded(element)).toBe(true);
-
-      row.triggerEventHandler('click', new MouseEvent('click'));
-      fixture.detectChanges();
-      expect(component.isExpanded(element)).toBe(false);
     });
 
     it('applies example-expanded-row class when row is expanded', () => {

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -97,9 +97,20 @@ describe('MatTable', () => {
       expect(component.columnsToDisplay()).toEqual(newColumns);
     });
 
+    it('columnsToRender updates when columnsToDisplay changes', () => {
+      const newColumns = [NAME_COLUMN, SYMBOL_COLUMN, ATOMIC_MASS_COLUMN];
+      component.columnsToDisplay.set(newColumns);
+      expect(component.columnsToRender()).toEqual([
+        ...columnNames(newColumns),
+        'expand',
+        RESIZE_SPACER_COLUMN,
+      ]);
+    });
+
     it('handles empty array of displayed columns', () => {
       component.columnsToDisplay.set([]);
       expect(component.columnsToDisplay()).toEqual([]);
+      expect(component.columnsToRender()).toEqual(['expand', RESIZE_SPACER_COLUMN]);
     });
 
     it('can set all columns from fullListOfColumns', () => {

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -325,16 +325,13 @@ export class MatTable {
 
   readonly dataSource = new MatTableDataSource(ELEMENT_DATA.elements);
   readonly columnsToDisplay = signal<ColumnDefinition[]>(DEFAULT_COLUMNS);
-  readonly columnsToDisplayWithExpand = computed(() => [
-    ...this.columnsToDisplay().map((column) => column.name),
-    'expand',
-  ]);
   // A trailing flexible spacer column absorbs any slack so the resizable columns
   // always render at their exact specified widths (never proportionally redistributed
   // by the fixed table layout), which keeps drag resizing stable when the table has
   // fewer columns than fill the viewport.
   readonly columnsToRender = computed(() => [
-    ...this.columnsToDisplayWithExpand(),
+    ...this.columnsToDisplay().map((column) => column.name),
+    'expand',
     RESIZE_SPACER_COLUMN,
   ]);
   readonly tableWidth = computed(() => {

--- a/tests/mat-table.spec.ts
+++ b/tests/mat-table.spec.ts
@@ -36,6 +36,17 @@ test.describe('Mat table tab', () => {
     expect(total).toBeGreaterThan(100);
   });
 
+  test('does not expand a row when the row body is clicked', async ({ page }) => {
+    const hydrogenRow = getRow(page, 0);
+    await expect(hydrogenRow).toContainText('Hydrogen');
+    await expect(hydrogenRow).not.toHaveClass(/example-expanded-row/);
+
+    await getFirstRowNameCell(page).click();
+
+    await expect(hydrogenRow).not.toHaveClass(/example-expanded-row/);
+    await expect(page.locator('div.example-element-detail-wrapper-expanded')).toHaveCount(0);
+  });
+
   test('uses the expand icon button to toggle row details and icon state', async ({ page }) => {
     const expandButton = getRow(page, 0).locator('button[aria-label="expand row"]');
     await expect(expandButton).toContainText('keyboard_arrow_down');

--- a/tests/mat-table.spec.ts
+++ b/tests/mat-table.spec.ts
@@ -36,21 +36,6 @@ test.describe('Mat table tab', () => {
     expect(total).toBeGreaterThan(100);
   });
 
-  test('expands and collapses details when a row is clicked', async ({ page }) => {
-    const hydrogenRow = getRow(page, 0);
-    await expect(hydrogenRow).toContainText('Hydrogen');
-    await expect(hydrogenRow).not.toHaveClass(/example-expanded-row/);
-
-    await hydrogenRow.click();
-    await expect(hydrogenRow).toHaveClass(/example-expanded-row/);
-    await expect(page.locator('div.example-element-detail-wrapper-expanded')).toContainText(
-      'Hydrogen',
-    );
-
-    await hydrogenRow.click();
-    await expect(hydrogenRow).not.toHaveClass(/example-expanded-row/);
-  });
-
   test('uses the expand icon button to toggle row details and icon state', async ({ page }) => {
     const expandButton = getRow(page, 0).locator('button[aria-label="expand row"]');
     await expect(expandButton).toContainText('keyboard_arrow_down');
@@ -61,10 +46,10 @@ test.describe('Mat table tab', () => {
   });
 
   test('allows only one expanded row at a time', async ({ page }) => {
-    await getRow(page, 0).click();
+    await getRow(page, 0).locator('button[aria-label="expand row"]').click();
     await expect(getRow(page, 0)).toHaveClass(/example-expanded-row/);
 
-    await getRow(page, 1).click();
+    await getRow(page, 1).locator('button[aria-label="expand row"]').click();
     await expect(getRow(page, 0)).not.toHaveClass(/example-expanded-row/);
     await expect(getRow(page, 1)).toHaveClass(/example-expanded-row/);
   });


### PR DESCRIPTION
# Pull Request

## Summary

Removes row-level click/keydown expansion handlers so detail toggling only happens via the explicit expand icon button. This aligns unit and Playwright tests with the intended interaction model and simplifies table state by inlining the expand column into `columnsToRender` and dropping the unused `columnsToDisplayWithExpand` computed signal.

Refreshes package-lock.json with newer resolved versions for dev and transitive packages, including Playwright 1.62.0 and related updates. This also reflects Playwright’s updated Node engine requirement (>=20) in the lockfile metadata.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that alters existing behavior)
- [x] Refactor or cleanup (no behavior change)
- [x] Tests (unit, scripts, or Playwright e2e)
- [ ] Build, CI, or tooling
- [x] Dependency update
- [ ] Documentation or AI instructions

## Areas Touched

- [x] Angular app (`src/`)
- [x] End-to-end tests (`tests/`)
- [ ] Node scripts (`scripts/`)
- [ ] CI or workflows (`.github/`)
- [ ] AI instructions (`AGENTS.md` and its generated copies)
- [x] Dependencies (`package.json` / `package-lock.json`)

## Related Issues

N/A

## How to Verify

Steps a reviewer can follow to confirm the change behaves as expected.

1. `npm ci`
2. `npm run start`, then open http://localhost:4200/
3. Verify

## Checklist

Mirror the CI pipeline in `.github/workflows/actions.yml` before requesting a review.

- [ ] Edited `AGENTS.md` (not the generated copies), then ran `npm run sync:agent-instructions`; `npm run sync:agent-instructions:check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (unit, scripts, and Playwright e2e)
- [x] `npm run build` succeeds
- [x] Tests added or updated to cover new or changed behavior
- [x] UI changes meet accessibility requirements (AXE clean, WCAG AA)
- [x] Documentation updated where applicable
