### PR TITLE
Persist mat-table column selection and widths in local storage

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,16 +4,16 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 Single-page Angular v22 demo app. Angular Material + CDK v22, TypeScript 6 (strict), npm (Node version pinned in `.nvmrc`). Two lazy-loaded routes defined in `src/app/app.routes.ts`; providers in `src/app/app.config.ts`; root component `src/app/app.ts` renders `<router-outlet />`.
 
-- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, column picker) and `ExampleIframe` (`iframe-resizer` demo).
+- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, resizable columns, column picker) and `ExampleIframe` (`iframe-resizer` demo). The displayed columns and their widths live in the `AppState` service and are persisted to local storage through the `LocalStorage` service, so they survive a reload.
 - `'toolbar'` → `MatToolbar` (`pages/mat-toolbar`): toolbar with a `mat-drawer` sidenav.
 
 ## Repository Map
 
 - `src/app/pages/<name>/` — route-level ("page") components loaded lazily from `app.routes.ts`.
 - `src/app/components/<name>/` — reusable components used across pages. Components are standalone, laid out as `<name>.{ts,html,scss,spec.ts}`.
-- `src/app/services/` — signal-based singletons (`selected-page`, `url-cache`), `providedIn: 'root'`.
-- `src/app/directives/` — `iframe-resizer` attribute directive (`[appIframeResizer]`).
-- `src/app/interfaces/` — types and periodic-element data (`data.ts`).
+- `src/app/services/` — signal-based singletons (`app-state`, `local-storage`, `url-cache`), declared with `@Service()`.
+- `src/app/directives/` — `column-resize` and `iframe-resizer` attribute directives (`[appColumnResize]`, `[appIframeResizer]`).
+- `src/app/interfaces/` — types plus shared data such as the periodic-element data (`data.ts`) and the table column definitions (`columns.ts`).
 - `tests/` — Playwright end-to-end specs and config.
 - `scripts/sync-agent-instructions.ts` — syncs `AGENTS.md` to all other AI instruction files.
 

--- a/.cursor/rules/cursor.mdc
+++ b/.cursor/rules/cursor.mdc
@@ -10,16 +10,16 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 Single-page Angular v22 demo app. Angular Material + CDK v22, TypeScript 6 (strict), npm (Node version pinned in `.nvmrc`). Two lazy-loaded routes defined in `src/app/app.routes.ts`; providers in `src/app/app.config.ts`; root component `src/app/app.ts` renders `<router-outlet />`.
 
-- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, column picker) and `ExampleIframe` (`iframe-resizer` demo).
+- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, resizable columns, column picker) and `ExampleIframe` (`iframe-resizer` demo). The displayed columns and their widths live in the `AppState` service and are persisted to local storage through the `LocalStorage` service, so they survive a reload.
 - `'toolbar'` → `MatToolbar` (`pages/mat-toolbar`): toolbar with a `mat-drawer` sidenav.
 
 ## Repository Map
 
 - `src/app/pages/<name>/` — route-level ("page") components loaded lazily from `app.routes.ts`.
 - `src/app/components/<name>/` — reusable components used across pages. Components are standalone, laid out as `<name>.{ts,html,scss,spec.ts}`.
-- `src/app/services/` — signal-based singletons (`selected-page`, `url-cache`), `providedIn: 'root'`.
-- `src/app/directives/` — `iframe-resizer` attribute directive (`[appIframeResizer]`).
-- `src/app/interfaces/` — types and periodic-element data (`data.ts`).
+- `src/app/services/` — signal-based singletons (`app-state`, `local-storage`, `url-cache`), declared with `@Service()`.
+- `src/app/directives/` — `column-resize` and `iframe-resizer` attribute directives (`[appColumnResize]`, `[appIframeResizer]`).
+- `src/app/interfaces/` — types plus shared data such as the periodic-element data (`data.ts`) and the table column definitions (`columns.ts`).
 - `tests/` — Playwright end-to-end specs and config.
 - `scripts/sync-agent-instructions.ts` — syncs `AGENTS.md` to all other AI instruction files.
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -4,16 +4,16 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 Single-page Angular v22 demo app. Angular Material + CDK v22, TypeScript 6 (strict), npm (Node version pinned in `.nvmrc`). Two lazy-loaded routes defined in `src/app/app.routes.ts`; providers in `src/app/app.config.ts`; root component `src/app/app.ts` renders `<router-outlet />`.
 
-- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, column picker) and `ExampleIframe` (`iframe-resizer` demo).
+- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, resizable columns, column picker) and `ExampleIframe` (`iframe-resizer` demo). The displayed columns and their widths live in the `AppState` service and are persisted to local storage through the `LocalStorage` service, so they survive a reload.
 - `'toolbar'` → `MatToolbar` (`pages/mat-toolbar`): toolbar with a `mat-drawer` sidenav.
 
 ## Repository Map
 
 - `src/app/pages/<name>/` — route-level ("page") components loaded lazily from `app.routes.ts`.
 - `src/app/components/<name>/` — reusable components used across pages. Components are standalone, laid out as `<name>.{ts,html,scss,spec.ts}`.
-- `src/app/services/` — signal-based singletons (`selected-page`, `url-cache`), `providedIn: 'root'`.
-- `src/app/directives/` — `iframe-resizer` attribute directive (`[appIframeResizer]`).
-- `src/app/interfaces/` — types and periodic-element data (`data.ts`).
+- `src/app/services/` — signal-based singletons (`app-state`, `local-storage`, `url-cache`), declared with `@Service()`.
+- `src/app/directives/` — `column-resize` and `iframe-resizer` attribute directives (`[appColumnResize]`, `[appIframeResizer]`).
+- `src/app/interfaces/` — types plus shared data such as the periodic-element data (`data.ts`) and the table column definitions (`columns.ts`).
 - `tests/` — Playwright end-to-end specs and config.
 - `scripts/sync-agent-instructions.ts` — syncs `AGENTS.md` to all other AI instruction files.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,16 +4,16 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 Single-page Angular v22 demo app. Angular Material + CDK v22, TypeScript 6 (strict), npm (Node version pinned in `.nvmrc`). Two lazy-loaded routes defined in `src/app/app.routes.ts`; providers in `src/app/app.config.ts`; root component `src/app/app.ts` renders `<router-outlet />`.
 
-- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, column picker) and `ExampleIframe` (`iframe-resizer` demo).
+- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, resizable columns, column picker) and `ExampleIframe` (`iframe-resizer` demo). The displayed columns and their widths live in the `AppState` service and are persisted to local storage through the `LocalStorage` service, so they survive a reload.
 - `'toolbar'` → `MatToolbar` (`pages/mat-toolbar`): toolbar with a `mat-drawer` sidenav.
 
 ## Repository Map
 
 - `src/app/pages/<name>/` — route-level ("page") components loaded lazily from `app.routes.ts`.
 - `src/app/components/<name>/` — reusable components used across pages. Components are standalone, laid out as `<name>.{ts,html,scss,spec.ts}`.
-- `src/app/services/` — signal-based singletons (`selected-page`, `url-cache`), `providedIn: 'root'`.
-- `src/app/directives/` — `iframe-resizer` attribute directive (`[appIframeResizer]`).
-- `src/app/interfaces/` — types and periodic-element data (`data.ts`).
+- `src/app/services/` — signal-based singletons (`app-state`, `local-storage`, `url-cache`), declared with `@Service()`.
+- `src/app/directives/` — `column-resize` and `iframe-resizer` attribute directives (`[appColumnResize]`, `[appIframeResizer]`).
+- `src/app/interfaces/` — types plus shared data such as the periodic-element data (`data.ts`) and the table column definitions (`columns.ts`).
 - `tests/` — Playwright end-to-end specs and config.
 - `scripts/sync-agent-instructions.ts` — syncs `AGENTS.md` to all other AI instruction files.
 

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -4,16 +4,16 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 Single-page Angular v22 demo app. Angular Material + CDK v22, TypeScript 6 (strict), npm (Node version pinned in `.nvmrc`). Two lazy-loaded routes defined in `src/app/app.routes.ts`; providers in `src/app/app.config.ts`; root component `src/app/app.ts` renders `<router-outlet />`.
 
-- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, column picker) and `ExampleIframe` (`iframe-resizer` demo).
+- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, resizable columns, column picker) and `ExampleIframe` (`iframe-resizer` demo). The displayed columns and their widths live in the `AppState` service and are persisted to local storage through the `LocalStorage` service, so they survive a reload.
 - `'toolbar'` → `MatToolbar` (`pages/mat-toolbar`): toolbar with a `mat-drawer` sidenav.
 
 ## Repository Map
 
 - `src/app/pages/<name>/` — route-level ("page") components loaded lazily from `app.routes.ts`.
 - `src/app/components/<name>/` — reusable components used across pages. Components are standalone, laid out as `<name>.{ts,html,scss,spec.ts}`.
-- `src/app/services/` — signal-based singletons (`selected-page`, `url-cache`), `providedIn: 'root'`.
-- `src/app/directives/` — `iframe-resizer` attribute directive (`[appIframeResizer]`).
-- `src/app/interfaces/` — types and periodic-element data (`data.ts`).
+- `src/app/services/` — signal-based singletons (`app-state`, `local-storage`, `url-cache`), declared with `@Service()`.
+- `src/app/directives/` — `column-resize` and `iframe-resizer` attribute directives (`[appColumnResize]`, `[appIframeResizer]`).
+- `src/app/interfaces/` — types plus shared data such as the periodic-element data (`data.ts`) and the table column definitions (`columns.ts`).
 - `tests/` — Playwright end-to-end specs and config.
 - `scripts/sync-agent-instructions.ts` — syncs `AGENTS.md` to all other AI instruction files.
 

--- a/.windsurf/rules/guidelines.md
+++ b/.windsurf/rules/guidelines.md
@@ -4,16 +4,16 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 Single-page Angular v22 demo app. Angular Material + CDK v22, TypeScript 6 (strict), npm (Node version pinned in `.nvmrc`). Two lazy-loaded routes defined in `src/app/app.routes.ts`; providers in `src/app/app.config.ts`; root component `src/app/app.ts` renders `<router-outlet />`.
 
-- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, column picker) and `ExampleIframe` (`iframe-resizer` demo).
+- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, resizable columns, column picker) and `ExampleIframe` (`iframe-resizer` demo). The displayed columns and their widths live in the `AppState` service and are persisted to local storage through the `LocalStorage` service, so they survive a reload.
 - `'toolbar'` → `MatToolbar` (`pages/mat-toolbar`): toolbar with a `mat-drawer` sidenav.
 
 ## Repository Map
 
 - `src/app/pages/<name>/` — route-level ("page") components loaded lazily from `app.routes.ts`.
 - `src/app/components/<name>/` — reusable components used across pages. Components are standalone, laid out as `<name>.{ts,html,scss,spec.ts}`.
-- `src/app/services/` — signal-based singletons (`selected-page`, `url-cache`), `providedIn: 'root'`.
-- `src/app/directives/` — `iframe-resizer` attribute directive (`[appIframeResizer]`).
-- `src/app/interfaces/` — types and periodic-element data (`data.ts`).
+- `src/app/services/` — signal-based singletons (`app-state`, `local-storage`, `url-cache`), declared with `@Service()`.
+- `src/app/directives/` — `column-resize` and `iframe-resizer` attribute directives (`[appColumnResize]`, `[appIframeResizer]`).
+- `src/app/interfaces/` — types plus shared data such as the periodic-element data (`data.ts`) and the table column definitions (`columns.ts`).
 - `tests/` — Playwright end-to-end specs and config.
 - `scripts/sync-agent-instructions.ts` — syncs `AGENTS.md` to all other AI instruction files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,16 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 
 Single-page Angular v22 demo app. Angular Material + CDK v22, TypeScript 6 (strict), npm (Node version pinned in `.nvmrc`). Two lazy-loaded routes defined in `src/app/app.routes.ts`; providers in `src/app/app.config.ts`; root component `src/app/app.ts` renders `<router-outlet />`.
 
-- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, column picker) and `ExampleIframe` (`iframe-resizer` demo).
+- `''` → `MatTabs` (`pages/mat-tabs`): tabs hosting `MatTable` (periodic-elements Material table: sort, filter, paginate, expandable rows, resizable columns, column picker) and `ExampleIframe` (`iframe-resizer` demo). The displayed columns and their widths live in the `AppState` service and are persisted to local storage through the `LocalStorage` service, so they survive a reload.
 - `'toolbar'` → `MatToolbar` (`pages/mat-toolbar`): toolbar with a `mat-drawer` sidenav.
 
 ## Repository Map
 
 - `src/app/pages/<name>/` — route-level ("page") components loaded lazily from `app.routes.ts`.
 - `src/app/components/<name>/` — reusable components used across pages. Components are standalone, laid out as `<name>.{ts,html,scss,spec.ts}`.
-- `src/app/services/` — signal-based singletons (`selected-page`, `url-cache`), `providedIn: 'root'`.
-- `src/app/directives/` — `iframe-resizer` attribute directive (`[appIframeResizer]`).
-- `src/app/interfaces/` — types and periodic-element data (`data.ts`).
+- `src/app/services/` — signal-based singletons (`app-state`, `local-storage`, `url-cache`), declared with `@Service()`.
+- `src/app/directives/` — `column-resize` and `iframe-resizer` attribute directives (`[appColumnResize]`, `[appIframeResizer]`).
+- `src/app/interfaces/` — types plus shared data such as the periodic-element data (`data.ts`) and the table column definitions (`columns.ts`).
 - `tests/` — Playwright end-to-end specs and config.
 - `scripts/sync-agent-instructions.ts` — syncs `AGENTS.md` to all other AI instruction files.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5754,9 +5754,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
-      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8906,9 +8906,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.1.tgz",
-      "integrity": "sha512-O81l1g31PlH55F7AChkGM3sdWZX+1KDLnhesJ/V9Ziug5nIOnEPaVb2jLWAo1TbCOSeZPeNbxX4v/ywTuKSn9A==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -2,6 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import { Router, provideRouter } from '@angular/router';
 import { App } from './app';
 import { routes } from './app.routes';
+import { MatTabs } from './pages/mat-tabs/mat-tabs';
+import { MatToolbar } from './pages/mat-toolbar/mat-toolbar';
 
 describe('App', () => {
   let router: Router;
@@ -11,6 +13,14 @@ describe('App', () => {
       imports: [App],
       providers: [provideRouter(routes)],
     });
+
+    /* These specs only assert which component each route resolves to. Rendering the real page
+       templates boots MatTable and a live iframe, which is by far the slowest work in the suite
+       and makes these tests flake against the default 5s timeout under parallel load. The page
+       templates are covered by mat-tabs.spec.ts and mat-toolbar.spec.ts. */
+    TestBed.overrideTemplate(MatTabs, '');
+    TestBed.overrideTemplate(MatToolbar, '');
+
     router = TestBed.inject(Router);
   });
 

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -21,9 +21,9 @@
     (detach)="isOpen.set(false)"
   >
     <app-column-select
-      [fullListOfColumns]="fullListOfColumns"
+      [fullListOfColumns]="fullListOfColumns()"
       [columnsToDisplay]="columnsToDisplay()"
-      (columnsToDisplayChange)="columnsToDisplay.set($event)"
+      (columnsToDisplayChange)="setColumnsToDisplay($event)"
     />
   </ng-template>
 </div>
@@ -45,7 +45,7 @@
             *matHeaderCellDef
             mat-sort-header
             [appColumnResize]="column.name"
-            [style.width.px]="columnWidth(column)"
+            [style.width.px]="column.width"
             (widthChange)="setColumnWidth(column.name, $event)"
           >
             {{ column.displayName }}
@@ -55,7 +55,7 @@
             mat-header-cell
             *matHeaderCellDef
             [appColumnResize]="column.name"
-            [style.width.px]="columnWidth(column)"
+            [style.width.px]="column.width"
             (widthChange)="setColumnWidth(column.name, $event)"
           >
             {{ column.displayName }}

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -3,8 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { vi } from 'vitest';
 import { ColumnDefinition } from '../../interfaces/column-definition';
-import { FilterState } from '../../interfaces/filter-state';
-import { ColumnSelect } from './column-select/column-select';
 import {
   ATOMIC_MASS_COLUMN,
   BOHR_MODEL_3D_COLUMN,
@@ -12,12 +10,15 @@ import {
   DEFAULT_COLUMNS,
   EXPAND_COLUMN_WIDTH,
   FULL_LIST_OF_COLUMNS,
-  MatTable,
   NAME_COLUMN,
   RESIZE_SPACER_COLUMN,
   SPECTRAL_IMG_COLUMN,
   SYMBOL_COLUMN,
-} from './mat-table';
+} from '../../interfaces/columns';
+import { FilterState } from '../../interfaces/filter-state';
+import { LocalStorage } from '../../services/local-storage';
+import { ColumnSelect } from './column-select/column-select';
+import { MatTable } from './mat-table';
 
 function columnNames(definitions: ColumnDefinition[]): string[] {
   return definitions.map((column) => column.name);
@@ -32,6 +33,14 @@ describe('MatTable', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatTable],
+      // Persistence is covered by the AppState tests; stub it out so the table tests stay
+      // isolated from whatever the environment's local storage contains.
+      providers: [
+        {
+          provide: LocalStorage,
+          useValue: { read: vi.fn(() => null), write: vi.fn(), remove: vi.fn() },
+        },
+      ],
     }).compileComponents();
 
     overlayContainer = TestBed.inject(OverlayContainer);
@@ -62,12 +71,8 @@ describe('MatTable', () => {
       ]);
     });
 
-    it('exposes fullListOfColumns constant', () => {
-      expect(component.fullListOfColumns).toBe(FULL_LIST_OF_COLUMNS);
-    });
-
-    it('exposes defaultColumns constant', () => {
-      expect(component.defaultColumns).toBe(DEFAULT_COLUMNS);
+    it('exposes fullListOfColumns from app state', () => {
+      expect(component.fullListOfColumns()).toEqual(FULL_LIST_OF_COLUMNS);
     });
 
     it('initializes expandedElement to null', () => {
@@ -93,13 +98,13 @@ describe('MatTable', () => {
   describe('Column Management', () => {
     it('updates columnsToDisplay signal', () => {
       const newColumns = [NAME_COLUMN, SYMBOL_COLUMN];
-      component.columnsToDisplay.set(newColumns);
+      component.setColumnsToDisplay(newColumns);
       expect(component.columnsToDisplay()).toEqual(newColumns);
     });
 
     it('columnsToRender updates when columnsToDisplay changes', () => {
       const newColumns = [NAME_COLUMN, SYMBOL_COLUMN, ATOMIC_MASS_COLUMN];
-      component.columnsToDisplay.set(newColumns);
+      component.setColumnsToDisplay(newColumns);
       expect(component.columnsToRender()).toEqual([
         ...columnNames(newColumns),
         'expand',
@@ -108,41 +113,53 @@ describe('MatTable', () => {
     });
 
     it('handles empty array of displayed columns', () => {
-      component.columnsToDisplay.set([]);
+      component.setColumnsToDisplay([]);
       expect(component.columnsToDisplay()).toEqual([]);
       expect(component.columnsToRender()).toEqual(['expand', RESIZE_SPACER_COLUMN]);
     });
 
     it('can set all columns from fullListOfColumns', () => {
-      component.columnsToDisplay.set(FULL_LIST_OF_COLUMNS);
+      component.setColumnsToDisplay(FULL_LIST_OF_COLUMNS);
       expect(component.columnsToDisplay()).toEqual(FULL_LIST_OF_COLUMNS);
     });
 
     it('can reset displayed columns to DEFAULT_COLUMNS', () => {
-      component.columnsToDisplay.set([NAME_COLUMN, SYMBOL_COLUMN]);
+      component.setColumnsToDisplay([NAME_COLUMN, SYMBOL_COLUMN]);
       expect(component.columnsToDisplay()).not.toEqual(DEFAULT_COLUMNS);
 
-      component.columnsToDisplay.set(DEFAULT_COLUMNS);
+      component.setColumnsToDisplay(DEFAULT_COLUMNS);
       expect(component.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
     });
   });
 
   describe('Column Resizing', () => {
-    it('returns the defined width for columns without an override', () => {
-      expect(component.columnWidth(NAME_COLUMN)).toBe(NAME_COLUMN.width);
+    function displayedWidth(name: string): number | undefined {
+      return component.columnsToDisplay().find((column) => column.name === name)?.width;
+    }
+
+    it('returns the defined width for columns that were never resized', () => {
+      expect(displayedWidth(NAME_COLUMN.name)).toBe(NAME_COLUMN.width);
     });
 
     it('stores and returns an explicit width for a column', () => {
       component.setColumnWidth('name', 240);
-      expect(component.columnWidth(NAME_COLUMN)).toBe(240);
+      expect(displayedWidth(NAME_COLUMN.name)).toBe(240);
     });
 
     it('preserves widths of other columns when one is resized', () => {
       component.setColumnWidth('name', 240);
       component.setColumnWidth('symbol', 90);
 
-      expect(component.columnWidth(NAME_COLUMN)).toBe(240);
-      expect(component.columnWidth(SYMBOL_COLUMN)).toBe(90);
+      expect(displayedWidth(NAME_COLUMN.name)).toBe(240);
+      expect(displayedWidth(SYMBOL_COLUMN.name)).toBe(90);
+    });
+
+    it('remembers the width of a column that is hidden and displayed again', () => {
+      component.setColumnWidth('name', 240);
+      component.setColumnsToDisplay([SYMBOL_COLUMN]);
+      component.setColumnsToDisplay([NAME_COLUMN, SYMBOL_COLUMN]);
+
+      expect(displayedWidth(NAME_COLUMN.name)).toBe(240);
     });
 
     it('computes tableWidth from default widths plus the expand column', () => {
@@ -159,10 +176,21 @@ describe('MatTable', () => {
 
     it('recomputes tableWidth when displayed columns change', () => {
       const displayed = [NAME_COLUMN, SYMBOL_COLUMN];
-      component.columnsToDisplay.set(displayed);
+      component.setColumnsToDisplay(displayed);
       const expected =
         displayed.reduce((total, column) => total + column.width, 0) + EXPAND_COLUMN_WIDTH;
       expect(component.tableWidth()).toBe(expected);
+    });
+
+    it('renders header widths from the column definitions', () => {
+      component.setColumnsToDisplay([NAME_COLUMN]);
+      component.setColumnWidth('name', 240);
+      fixture.detectChanges();
+
+      const header = fixture.nativeElement as HTMLElement;
+      const nameHeader = header.querySelector<HTMLElement>('th.mat-column-name');
+
+      expect(nameHeader?.style.width).toBe('240px');
     });
 
     it('exposes the expand column width constant', () => {
@@ -175,7 +203,7 @@ describe('MatTable', () => {
     });
 
     it('keeps the spacer column present even with no displayed columns', () => {
-      component.columnsToDisplay.set([]);
+      component.setColumnsToDisplay([]);
       expect(component.columnsToRender()).toEqual(['expand', RESIZE_SPACER_COLUMN]);
     });
 
@@ -444,7 +472,7 @@ describe('MatTable', () => {
     }
 
     beforeEach(() => {
-      component.columnsToDisplay.set([
+      component.setColumnsToDisplay([
         NAME_COLUMN,
         BOHR_MODEL_IMAGE_COLUMN,
         BOHR_MODEL_3D_COLUMN,
@@ -697,7 +725,7 @@ describe('MatTable', () => {
       const initialHeaders = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
       const initialCount = initialHeaders.length;
 
-      component.columnsToDisplay.set([NAME_COLUMN, SYMBOL_COLUMN]);
+      component.setColumnsToDisplay([NAME_COLUMN, SYMBOL_COLUMN]);
       fixture.detectChanges();
 
       const updatedHeaders = fixture.debugElement.queryAll(By.css('th[mat-header-cell]'));
@@ -706,7 +734,7 @@ describe('MatTable', () => {
     });
 
     it('expandedDetail row maintains proper colspan after column change', () => {
-      component.columnsToDisplay.set([NAME_COLUMN, SYMBOL_COLUMN]);
+      component.setColumnsToDisplay([NAME_COLUMN, SYMBOL_COLUMN]);
       fixture.detectChanges();
 
       // Find the detail row cell with the example-element-detail-wrapper
@@ -737,10 +765,10 @@ describe('MatTable', () => {
 
     it('handles rapid column changes', () => {
       expect(() => {
-        component.columnsToDisplay.set([NAME_COLUMN]);
-        component.columnsToDisplay.set([SYMBOL_COLUMN]);
-        component.columnsToDisplay.set([ATOMIC_MASS_COLUMN]);
-        component.columnsToDisplay.set(DEFAULT_COLUMNS);
+        component.setColumnsToDisplay([NAME_COLUMN]);
+        component.setColumnsToDisplay([SYMBOL_COLUMN]);
+        component.setColumnsToDisplay([ATOMIC_MASS_COLUMN]);
+        component.setColumnsToDisplay(DEFAULT_COLUMNS);
       }).not.toThrow();
 
       expect(component.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -1,6 +1,6 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import { NgOptimizedImage } from '@angular/common';
-import { Component, computed, effect, signal, viewChild } from '@angular/core';
+import { Component, computed, effect, inject, signal, viewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
@@ -8,294 +8,14 @@ import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { ColumnResize } from '../../directives/column-resize';
 import { ColumnDefinition } from '../../interfaces/column-definition';
+import { EXPAND_COLUMN_WIDTH, RESIZE_SPACER_COLUMN } from '../../interfaces/columns';
 import { ELEMENT_DATA } from '../../interfaces/data';
 import { FilterState } from '../../interfaces/filter-state';
 import { PeriodicElement } from '../../interfaces/periodic-element';
+import { AppState } from '../../services/app-state';
 import { ColumnSelect } from './column-select/column-select';
 import { Filter } from './filter/filter';
 import { PeriodicElementDetail } from './periodic-element-detail/periodic-element-detail';
-
-export const DEFAULT_COLUMN_WIDTH = 150;
-export const EXPAND_COLUMN_WIDTH = 56;
-export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
-
-// Most columns use DEFAULT_COLUMN_WIDTH, with a few tuned to wider values where
-// their content warrants it. The explicit per-column `width` makes it easy to
-// adjust any column to an appropriate value.
-export const NAME_COLUMN: ColumnDefinition = {
-  name: 'name',
-  displayName: 'Name',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const APPEARANCE_COLUMN: ColumnDefinition = {
-  name: 'appearance',
-  displayName: 'Appearance',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const ATOMIC_MASS_COLUMN: ColumnDefinition = {
-  name: 'atomic_mass',
-  displayName: 'Atomic Mass',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const BOIL_COLUMN: ColumnDefinition = {
-  name: 'boil',
-  displayName: 'Boiling Point',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const CATEGORY_COLUMN: ColumnDefinition = {
-  name: 'category',
-  displayName: 'Category',
-  isSortable: true,
-  width: 200,
-};
-
-export const DENSITY_COLUMN: ColumnDefinition = {
-  name: 'density',
-  displayName: 'Density',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const DISCOVERED_BY_COLUMN: ColumnDefinition = {
-  name: 'discovered_by',
-  displayName: 'Discovered By',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const MELT_COLUMN: ColumnDefinition = {
-  name: 'melt',
-  displayName: 'Melting Point',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const MOLAR_HEAT_COLUMN: ColumnDefinition = {
-  name: 'molar_heat',
-  displayName: 'Molar Heat',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const NAMED_BY_COLUMN: ColumnDefinition = {
-  name: 'named_by',
-  displayName: 'Named By',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const NUMBER_COLUMN: ColumnDefinition = {
-  name: 'number',
-  displayName: 'Number',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const PERIOD_COLUMN: ColumnDefinition = {
-  name: 'period',
-  displayName: 'Period',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const GROUP_COLUMN: ColumnDefinition = {
-  name: 'group',
-  displayName: 'Group',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const PHASE_COLUMN: ColumnDefinition = {
-  name: 'phase',
-  displayName: 'Phase',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const BOHR_MODEL_IMAGE_COLUMN: ColumnDefinition = {
-  name: 'bohr_model_image',
-  displayName: 'Bohr Model Image',
-  isSortable: false,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const BOHR_MODEL_3D_COLUMN: ColumnDefinition = {
-  name: 'bohr_model_3d',
-  displayName: 'Bohr Model 3D',
-  isSortable: false,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const SPECTRAL_IMG_COLUMN: ColumnDefinition = {
-  name: 'spectral_img',
-  displayName: 'Spectral Image',
-  isSortable: false,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const SUMMARY_COLUMN: ColumnDefinition = {
-  name: 'summary',
-  displayName: 'Summary',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const SYMBOL_COLUMN: ColumnDefinition = {
-  name: 'symbol',
-  displayName: 'Symbol',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const XPOS_COLUMN: ColumnDefinition = {
-  name: 'xpos',
-  displayName: 'X Position',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const YPOS_COLUMN: ColumnDefinition = {
-  name: 'ypos',
-  displayName: 'Y Position',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const WXPOS_COLUMN: ColumnDefinition = {
-  name: 'wxpos',
-  displayName: 'Wide X Position',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const WYPOS_COLUMN: ColumnDefinition = {
-  name: 'wypos',
-  displayName: 'Wide Y Position',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const SHELLS_COLUMN: ColumnDefinition = {
-  name: 'shells',
-  displayName: 'Shells',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const ELECTRON_CONFIGURATION_COLUMN: ColumnDefinition = {
-  name: 'electron_configuration',
-  displayName: 'Electron Configuration',
-  isSortable: true,
-  width: 200,
-};
-
-export const ELECTRON_CONFIGURATION_SEMANTIC_COLUMN: ColumnDefinition = {
-  name: 'electron_configuration_semantic',
-  displayName: 'Electron Configuration (Semantic)',
-  isSortable: true,
-  width: 300,
-};
-
-export const ELECTRON_AFFINITY_COLUMN: ColumnDefinition = {
-  name: 'electron_affinity',
-  displayName: 'Electron Affinity',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const ELECTRONEGATIVITY_PAULING_COLUMN: ColumnDefinition = {
-  name: 'electronegativity_pauling',
-  displayName: 'Electronegativity (Pauling)',
-  isSortable: true,
-  width: 250,
-};
-
-export const IONIZATION_ENERGIES_COLUMN: ColumnDefinition = {
-  name: 'ionization_energies',
-  displayName: 'Ionization Energies',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const IMAGE_COLUMN: ColumnDefinition = {
-  name: 'image',
-  displayName: 'Image',
-  isSortable: false,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-export const BLOCK_COLUMN: ColumnDefinition = {
-  name: 'block',
-  displayName: 'Block',
-  isSortable: true,
-  width: DEFAULT_COLUMN_WIDTH,
-};
-
-// `source` is shown by default but intentionally omitted from the column
-// chooser's full list, so it isn't part of FULL_LIST_OF_COLUMNS.
-export const SOURCE_COLUMN: ColumnDefinition = {
-  name: 'source',
-  displayName: 'Source',
-  isSortable: false,
-  width: 300,
-};
-
-export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
-  NAME_COLUMN,
-  APPEARANCE_COLUMN,
-  ATOMIC_MASS_COLUMN,
-  BOIL_COLUMN,
-  CATEGORY_COLUMN,
-  DENSITY_COLUMN,
-  DISCOVERED_BY_COLUMN,
-  MELT_COLUMN,
-  MOLAR_HEAT_COLUMN,
-  NAMED_BY_COLUMN,
-  NUMBER_COLUMN,
-  PERIOD_COLUMN,
-  GROUP_COLUMN,
-  PHASE_COLUMN,
-  BOHR_MODEL_IMAGE_COLUMN,
-  BOHR_MODEL_3D_COLUMN,
-  SPECTRAL_IMG_COLUMN,
-  SUMMARY_COLUMN,
-  SYMBOL_COLUMN,
-  XPOS_COLUMN,
-  YPOS_COLUMN,
-  WXPOS_COLUMN,
-  WYPOS_COLUMN,
-  SHELLS_COLUMN,
-  ELECTRON_CONFIGURATION_COLUMN,
-  ELECTRON_CONFIGURATION_SEMANTIC_COLUMN,
-  ELECTRON_AFFINITY_COLUMN,
-  ELECTRONEGATIVITY_PAULING_COLUMN,
-  IONIZATION_ENERGIES_COLUMN,
-  IMAGE_COLUMN,
-  BLOCK_COLUMN,
-];
-
-export const DEFAULT_COLUMNS: ColumnDefinition[] = [
-  NAME_COLUMN,
-  ATOMIC_MASS_COLUMN,
-  SYMBOL_COLUMN,
-  NUMBER_COLUMN,
-  CATEGORY_COLUMN,
-  PERIOD_COLUMN,
-  GROUP_COLUMN,
-  PHASE_COLUMN,
-  SOURCE_COLUMN,
-  ELECTRON_CONFIGURATION_COLUMN,
-  ELECTRON_CONFIGURATION_SEMANTIC_COLUMN,
-  BLOCK_COLUMN,
-];
 
 @Component({
   selector: 'app-mat-table',
@@ -316,6 +36,7 @@ export const DEFAULT_COLUMNS: ColumnDefinition[] = [
   styleUrl: './mat-table.scss',
 })
 export class MatTable {
+  private readonly appState = inject(AppState);
   private readonly emptyFilterState: FilterState = { name: '' };
   private cachedFilterString = JSON.stringify(this.emptyFilterState);
   private cachedFilterState = this.emptyFilterState;
@@ -324,7 +45,9 @@ export class MatTable {
   readonly sort = viewChild(MatSort);
 
   readonly dataSource = new MatTableDataSource(ELEMENT_DATA.elements);
-  readonly columnsToDisplay = signal<ColumnDefinition[]>(DEFAULT_COLUMNS);
+  // Column selection and widths are owned by AppState so they survive a page reload.
+  readonly columnsToDisplay = this.appState.columnsToDisplay;
+  readonly fullListOfColumns = this.appState.fullListOfColumns;
   // A trailing flexible spacer column absorbs any slack so the resizable columns
   // always render at their exact specified widths (never proportionally redistributed
   // by the fixed table layout), which keeps drag resizing stable when the table has
@@ -335,20 +58,13 @@ export class MatTable {
     RESIZE_SPACER_COLUMN,
   ]);
   readonly tableWidth = computed(() => {
-    const widths = this.columnWidths();
-    const dataTotal = this.columnsToDisplay().reduce(
-      (total, column) => total + (widths[column.name] ?? column.width),
-      0,
-    );
+    const dataTotal = this.columnsToDisplay().reduce((total, column) => total + column.width, 0);
 
     return dataTotal + EXPAND_COLUMN_WIDTH;
   });
   readonly resizeSpacerColumn = RESIZE_SPACER_COLUMN;
-  readonly fullListOfColumns = FULL_LIST_OF_COLUMNS;
-  readonly defaultColumns = DEFAULT_COLUMNS;
   readonly expandedElement = signal<PeriodicElement | null>(null);
   readonly isOpen = signal(false);
-  readonly columnWidths = signal<Record<string, number>>({});
   readonly expandColumnWidth = EXPAND_COLUMN_WIDTH;
 
   constructor() {
@@ -405,16 +121,16 @@ export class MatTable {
     return this.expandedElement() === element;
   }
 
-  columnWidth(column: ColumnDefinition): number {
-    return this.columnWidths()[column.name] ?? column.width;
-  }
-
   imageAlt(element: PeriodicElement, column: ColumnDefinition): string {
     return `${element.name} ${column.displayName.toLowerCase()}`;
   }
 
+  setColumnsToDisplay(columns: ColumnDefinition[]): void {
+    this.appState.setColumnsToDisplay(columns);
+  }
+
   setColumnWidth(column: string, width: number): void {
-    this.columnWidths.update((widths) => ({ ...widths, [column]: width }));
+    this.appState.setColumnWidth(column, width);
   }
 
   private getCachedFilterState(filter: string): FilterState {

--- a/src/app/interfaces/columns.ts
+++ b/src/app/interfaces/columns.ts
@@ -1,0 +1,288 @@
+import { ColumnDefinition } from './column-definition';
+
+export const DEFAULT_COLUMN_WIDTH = 150;
+export const EXPAND_COLUMN_WIDTH = 56;
+export const RESIZE_SPACER_COLUMN = 'resizeSpacer';
+
+// Most columns use DEFAULT_COLUMN_WIDTH, with a few tuned to wider values where
+// their content warrants it. The explicit per-column `width` makes it easy to
+// adjust any column to an appropriate value.
+export const NAME_COLUMN: ColumnDefinition = {
+  name: 'name',
+  displayName: 'Name',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const APPEARANCE_COLUMN: ColumnDefinition = {
+  name: 'appearance',
+  displayName: 'Appearance',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const ATOMIC_MASS_COLUMN: ColumnDefinition = {
+  name: 'atomic_mass',
+  displayName: 'Atomic Mass',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const BOIL_COLUMN: ColumnDefinition = {
+  name: 'boil',
+  displayName: 'Boiling Point',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const CATEGORY_COLUMN: ColumnDefinition = {
+  name: 'category',
+  displayName: 'Category',
+  isSortable: true,
+  width: 200,
+};
+
+export const DENSITY_COLUMN: ColumnDefinition = {
+  name: 'density',
+  displayName: 'Density',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const DISCOVERED_BY_COLUMN: ColumnDefinition = {
+  name: 'discovered_by',
+  displayName: 'Discovered By',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const MELT_COLUMN: ColumnDefinition = {
+  name: 'melt',
+  displayName: 'Melting Point',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const MOLAR_HEAT_COLUMN: ColumnDefinition = {
+  name: 'molar_heat',
+  displayName: 'Molar Heat',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const NAMED_BY_COLUMN: ColumnDefinition = {
+  name: 'named_by',
+  displayName: 'Named By',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const NUMBER_COLUMN: ColumnDefinition = {
+  name: 'number',
+  displayName: 'Number',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const PERIOD_COLUMN: ColumnDefinition = {
+  name: 'period',
+  displayName: 'Period',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const GROUP_COLUMN: ColumnDefinition = {
+  name: 'group',
+  displayName: 'Group',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const PHASE_COLUMN: ColumnDefinition = {
+  name: 'phase',
+  displayName: 'Phase',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const BOHR_MODEL_IMAGE_COLUMN: ColumnDefinition = {
+  name: 'bohr_model_image',
+  displayName: 'Bohr Model Image',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const BOHR_MODEL_3D_COLUMN: ColumnDefinition = {
+  name: 'bohr_model_3d',
+  displayName: 'Bohr Model 3D',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const SPECTRAL_IMG_COLUMN: ColumnDefinition = {
+  name: 'spectral_img',
+  displayName: 'Spectral Image',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const SUMMARY_COLUMN: ColumnDefinition = {
+  name: 'summary',
+  displayName: 'Summary',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const SYMBOL_COLUMN: ColumnDefinition = {
+  name: 'symbol',
+  displayName: 'Symbol',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const XPOS_COLUMN: ColumnDefinition = {
+  name: 'xpos',
+  displayName: 'X Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const YPOS_COLUMN: ColumnDefinition = {
+  name: 'ypos',
+  displayName: 'Y Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const WXPOS_COLUMN: ColumnDefinition = {
+  name: 'wxpos',
+  displayName: 'Wide X Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const WYPOS_COLUMN: ColumnDefinition = {
+  name: 'wypos',
+  displayName: 'Wide Y Position',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const SHELLS_COLUMN: ColumnDefinition = {
+  name: 'shells',
+  displayName: 'Shells',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const ELECTRON_CONFIGURATION_COLUMN: ColumnDefinition = {
+  name: 'electron_configuration',
+  displayName: 'Electron Configuration',
+  isSortable: true,
+  width: 200,
+};
+
+export const ELECTRON_CONFIGURATION_SEMANTIC_COLUMN: ColumnDefinition = {
+  name: 'electron_configuration_semantic',
+  displayName: 'Electron Configuration (Semantic)',
+  isSortable: true,
+  width: 300,
+};
+
+export const ELECTRON_AFFINITY_COLUMN: ColumnDefinition = {
+  name: 'electron_affinity',
+  displayName: 'Electron Affinity',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const ELECTRONEGATIVITY_PAULING_COLUMN: ColumnDefinition = {
+  name: 'electronegativity_pauling',
+  displayName: 'Electronegativity (Pauling)',
+  isSortable: true,
+  width: 250,
+};
+
+export const IONIZATION_ENERGIES_COLUMN: ColumnDefinition = {
+  name: 'ionization_energies',
+  displayName: 'Ionization Energies',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const IMAGE_COLUMN: ColumnDefinition = {
+  name: 'image',
+  displayName: 'Image',
+  isSortable: false,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+export const BLOCK_COLUMN: ColumnDefinition = {
+  name: 'block',
+  displayName: 'Block',
+  isSortable: true,
+  width: DEFAULT_COLUMN_WIDTH,
+};
+
+// `source` is shown by default but intentionally omitted from the column
+// chooser's full list, so it isn't part of FULL_LIST_OF_COLUMNS.
+export const SOURCE_COLUMN: ColumnDefinition = {
+  name: 'source',
+  displayName: 'Source',
+  isSortable: false,
+  width: 300,
+};
+
+export const FULL_LIST_OF_COLUMNS: ColumnDefinition[] = [
+  NAME_COLUMN,
+  APPEARANCE_COLUMN,
+  ATOMIC_MASS_COLUMN,
+  BOIL_COLUMN,
+  CATEGORY_COLUMN,
+  DENSITY_COLUMN,
+  DISCOVERED_BY_COLUMN,
+  MELT_COLUMN,
+  MOLAR_HEAT_COLUMN,
+  NAMED_BY_COLUMN,
+  NUMBER_COLUMN,
+  PERIOD_COLUMN,
+  GROUP_COLUMN,
+  PHASE_COLUMN,
+  BOHR_MODEL_IMAGE_COLUMN,
+  BOHR_MODEL_3D_COLUMN,
+  SPECTRAL_IMG_COLUMN,
+  SUMMARY_COLUMN,
+  SYMBOL_COLUMN,
+  XPOS_COLUMN,
+  YPOS_COLUMN,
+  WXPOS_COLUMN,
+  WYPOS_COLUMN,
+  SHELLS_COLUMN,
+  ELECTRON_CONFIGURATION_COLUMN,
+  ELECTRON_CONFIGURATION_SEMANTIC_COLUMN,
+  ELECTRON_AFFINITY_COLUMN,
+  ELECTRONEGATIVITY_PAULING_COLUMN,
+  IONIZATION_ENERGIES_COLUMN,
+  IMAGE_COLUMN,
+  BLOCK_COLUMN,
+];
+
+export const DEFAULT_COLUMNS: ColumnDefinition[] = [
+  NAME_COLUMN,
+  ATOMIC_MASS_COLUMN,
+  SYMBOL_COLUMN,
+  NUMBER_COLUMN,
+  CATEGORY_COLUMN,
+  PERIOD_COLUMN,
+  GROUP_COLUMN,
+  PHASE_COLUMN,
+  SOURCE_COLUMN,
+  ELECTRON_CONFIGURATION_COLUMN,
+  ELECTRON_CONFIGURATION_SEMANTIC_COLUMN,
+  BLOCK_COLUMN,
+];
+
+// Every column the app knows about. `SOURCE_COLUMN` is displayed by default but is
+// intentionally absent from FULL_LIST_OF_COLUMNS (the column chooser's list), so it is
+// appended here to keep the catalog complete.
+export const ALL_COLUMNS: ColumnDefinition[] = [...FULL_LIST_OF_COLUMNS, SOURCE_COLUMN];

--- a/src/app/services/app-state.spec.ts
+++ b/src/app/services/app-state.spec.ts
@@ -1,5 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { ColumnDefinition } from '../interfaces/column-definition';
 import {
   ATOMIC_MASS_COLUMN,
@@ -8,7 +9,12 @@ import {
   NAME_COLUMN,
   SYMBOL_COLUMN,
 } from '../interfaces/columns';
-import { AppState, PersistedTableState, TABLE_STATE_STORAGE_KEY } from './app-state';
+import {
+  AppState,
+  PERSIST_DEBOUNCE_MS,
+  PersistedTableState,
+  TABLE_STATE_STORAGE_KEY,
+} from './app-state';
 
 function createStorage(entries: Record<string, string> = {}): Storage {
   const values = new Map(Object.entries(entries));
@@ -35,9 +41,34 @@ function storedState(storage: Storage): PersistedTableState | null {
   return rawValue === null ? null : (JSON.parse(rawValue) as PersistedTableState);
 }
 
+let pageHideListeners: (() => void)[] = [];
+
+function createWindow(storage: Storage) {
+  return {
+    localStorage: storage,
+    addEventListener: (type: string, listener: () => void) => {
+      if (type === 'pagehide') {
+        pageHideListeners.push(listener);
+      }
+    },
+    removeEventListener: (type: string, listener: () => void) => {
+      if (type === 'pagehide') {
+        pageHideListeners = pageHideListeners.filter((current) => current !== listener);
+      }
+    },
+  };
+}
+
+/** Simulates the browser tearing the page down, for example on reload. */
+function hidePage(): void {
+  for (const listener of pageHideListeners) {
+    listener();
+  }
+}
+
 function createService(storage: Storage): AppState {
   TestBed.configureTestingModule({
-    providers: [{ provide: DOCUMENT, useValue: { defaultView: { localStorage: storage } } }],
+    providers: [{ provide: DOCUMENT, useValue: { defaultView: createWindow(storage) } }],
   });
 
   return TestBed.inject(AppState);
@@ -52,6 +83,10 @@ function columnNames(columns: ColumnDefinition[]): string[] {
 }
 
 describe('AppState', () => {
+  beforeEach(() => {
+    pageHideListeners = [];
+  });
+
   describe('with empty storage', () => {
     let storage: Storage;
     let service: AppState;
@@ -134,21 +169,32 @@ describe('AppState', () => {
     let storage: Storage;
     let service: AppState;
 
+    /** Flushes the state to storage the way a settled UI would. */
+    function settle(): void {
+      TestBed.tick();
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS);
+    }
+
     beforeEach(() => {
+      vi.useFakeTimers();
       storage = createStorage();
       service = createService(storage);
     });
 
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('persists the displayed columns', () => {
       service.setColumnsToDisplay([NAME_COLUMN, SYMBOL_COLUMN]);
-      TestBed.tick();
+      settle();
 
       expect(storedState(storage)?.displayedColumns).toEqual(['name', 'symbol']);
     });
 
     it('persists only the widths that differ from the defaults', () => {
       service.setColumnWidth('name', 240);
-      TestBed.tick();
+      settle();
 
       expect(storedState(storage)?.columnWidths).toEqual({ name: 240 });
     });
@@ -156,16 +202,67 @@ describe('AppState', () => {
     it('persists widths of columns that are not displayed', () => {
       service.setColumnWidth('appearance', 240);
       service.setColumnsToDisplay([NAME_COLUMN]);
-      TestBed.tick();
+      settle();
 
       expect(storedState(storage)?.columnWidths).toEqual({ appearance: 240 });
     });
 
     it('persists an empty selection when every column is hidden', () => {
       service.setColumnsToDisplay([]);
-      TestBed.tick();
+      settle();
 
       expect(storedState(storage)?.displayedColumns).toEqual([]);
+    });
+
+    it('waits for the state to settle before writing', () => {
+      const setItem = vi.spyOn(storage, 'setItem');
+
+      service.setColumnWidth('name', 240);
+      TestBed.tick();
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS - 1);
+
+      expect(setItem).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+
+      expect(setItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('flushes a pending write when the page is being hidden', () => {
+      service.setColumnWidth('name', 240);
+      TestBed.tick();
+
+      hidePage();
+
+      expect(storedState(storage)?.columnWidths).toEqual({ name: 240 });
+    });
+
+    it('does not write again when nothing is pending', () => {
+      service.setColumnWidth('name', 240);
+      settle();
+      const setItem = vi.spyOn(storage, 'setItem');
+
+      hidePage();
+
+      expect(setItem).not.toHaveBeenCalled();
+    });
+
+    it('coalesces a burst of width updates into a single write', () => {
+      const setItem = vi.spyOn(storage, 'setItem');
+
+      // A drag resize emits a new width on every pointer move.
+      for (const width of [200, 220, 240, 260]) {
+        service.setColumnWidth('name', width);
+        TestBed.tick();
+        vi.advanceTimersByTime(16);
+      }
+
+      expect(setItem).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS);
+
+      expect(setItem).toHaveBeenCalledTimes(1);
+      expect(storedState(storage)?.columnWidths).toEqual({ name: 260 });
     });
   });
 

--- a/src/app/services/app-state.spec.ts
+++ b/src/app/services/app-state.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { AppState } from './app-state';
+
+describe('AppState', () => {
+  let service: AppState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AppState);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/app-state.spec.ts
+++ b/src/app/services/app-state.spec.ts
@@ -1,15 +1,266 @@
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
-import { AppState } from './app-state';
+import { ColumnDefinition } from '../interfaces/column-definition';
+import {
+  ATOMIC_MASS_COLUMN,
+  DEFAULT_COLUMNS,
+  FULL_LIST_OF_COLUMNS,
+  NAME_COLUMN,
+  SYMBOL_COLUMN,
+} from '../interfaces/columns';
+import { AppState, PersistedTableState, TABLE_STATE_STORAGE_KEY } from './app-state';
 
-describe('AppState', () => {
-  let service: AppState;
+function createStorage(entries: Record<string, string> = {}): Storage {
+  const values = new Map(Object.entries(entries));
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(AppState);
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+}
+
+function storedState(storage: Storage): PersistedTableState | null {
+  const rawValue = storage.getItem(TABLE_STATE_STORAGE_KEY);
+
+  return rawValue === null ? null : (JSON.parse(rawValue) as PersistedTableState);
+}
+
+function createService(storage: Storage): AppState {
+  TestBed.configureTestingModule({
+    providers: [{ provide: DOCUMENT, useValue: { defaultView: { localStorage: storage } } }],
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  return TestBed.inject(AppState);
+}
+
+function widthOf(columns: ColumnDefinition[], name: string): number | undefined {
+  return columns.find((column) => column.name === name)?.width;
+}
+
+function columnNames(columns: ColumnDefinition[]): string[] {
+  return columns.map((column) => column.name);
+}
+
+describe('AppState', () => {
+  describe('with empty storage', () => {
+    let storage: Storage;
+    let service: AppState;
+
+    beforeEach(() => {
+      storage = createStorage();
+      service = createService(storage);
+    });
+
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('displays the default columns', () => {
+      expect(service.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
+    });
+
+    it('exposes the full list of selectable columns', () => {
+      expect(service.fullListOfColumns()).toEqual(FULL_LIST_OF_COLUMNS);
+    });
+
+    it('replaces the displayed columns', () => {
+      service.setColumnsToDisplay([SYMBOL_COLUMN, NAME_COLUMN]);
+
+      expect(service.columnsToDisplay()).toEqual([SYMBOL_COLUMN, NAME_COLUMN]);
+    });
+
+    it('ignores unknown columns when setting the displayed columns', () => {
+      const unknownColumn: ColumnDefinition = {
+        name: 'unknown',
+        displayName: 'Unknown',
+        isSortable: false,
+        width: 100,
+      };
+
+      service.setColumnsToDisplay([NAME_COLUMN, unknownColumn]);
+
+      expect(service.columnsToDisplay()).toEqual([NAME_COLUMN]);
+    });
+
+    it('ignores duplicated columns when setting the displayed columns', () => {
+      service.setColumnsToDisplay([NAME_COLUMN, NAME_COLUMN, SYMBOL_COLUMN]);
+
+      expect(columnNames(service.columnsToDisplay())).toEqual(['name', 'symbol']);
+    });
+
+    it('applies a new width to the column definition', () => {
+      service.setColumnWidth('name', 240);
+
+      expect(widthOf(service.columnsToDisplay(), 'name')).toBe(240);
+      expect(widthOf(service.fullListOfColumns(), 'name')).toBe(240);
+    });
+
+    it('keeps the width of a column that is hidden and displayed again', () => {
+      service.setColumnWidth('atomic_mass', 320);
+      service.setColumnsToDisplay([NAME_COLUMN]);
+      service.setColumnsToDisplay([NAME_COLUMN, ATOMIC_MASS_COLUMN]);
+
+      expect(widthOf(service.columnsToDisplay(), 'atomic_mass')).toBe(320);
+    });
+
+    it('ignores widths for unknown columns', () => {
+      expect(() => {
+        service.setColumnWidth('unknown', 240);
+      }).not.toThrow();
+      expect(service.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
+    });
+
+    it.each([0, -10, Number.NaN, Number.POSITIVE_INFINITY])(
+      'ignores the invalid width %s',
+      (width) => {
+        service.setColumnWidth('name', width);
+
+        expect(widthOf(service.columnsToDisplay(), 'name')).toBe(NAME_COLUMN.width);
+      },
+    );
+  });
+
+  describe('persistence', () => {
+    let storage: Storage;
+    let service: AppState;
+
+    beforeEach(() => {
+      storage = createStorage();
+      service = createService(storage);
+    });
+
+    it('persists the displayed columns', () => {
+      service.setColumnsToDisplay([NAME_COLUMN, SYMBOL_COLUMN]);
+      TestBed.tick();
+
+      expect(storedState(storage)?.displayedColumns).toEqual(['name', 'symbol']);
+    });
+
+    it('persists only the widths that differ from the defaults', () => {
+      service.setColumnWidth('name', 240);
+      TestBed.tick();
+
+      expect(storedState(storage)?.columnWidths).toEqual({ name: 240 });
+    });
+
+    it('persists widths of columns that are not displayed', () => {
+      service.setColumnWidth('appearance', 240);
+      service.setColumnsToDisplay([NAME_COLUMN]);
+      TestBed.tick();
+
+      expect(storedState(storage)?.columnWidths).toEqual({ appearance: 240 });
+    });
+
+    it('persists an empty selection when every column is hidden', () => {
+      service.setColumnsToDisplay([]);
+      TestBed.tick();
+
+      expect(storedState(storage)?.displayedColumns).toEqual([]);
+    });
+  });
+
+  describe('hydration', () => {
+    function hydrate(value: unknown): AppState {
+      return createService(createStorage({ [TABLE_STATE_STORAGE_KEY]: JSON.stringify(value) }));
+    }
+
+    it('restores the displayed columns from storage', () => {
+      const service = hydrate({ displayedColumns: ['symbol', 'name'], columnWidths: {} });
+
+      expect(columnNames(service.columnsToDisplay())).toEqual(['symbol', 'name']);
+    });
+
+    it('restores column widths from storage', () => {
+      const service = hydrate({ displayedColumns: ['name'], columnWidths: { name: 240 } });
+
+      expect(widthOf(service.columnsToDisplay(), 'name')).toBe(240);
+    });
+
+    it('restores widths of columns that are not displayed', () => {
+      const service = hydrate({ displayedColumns: ['name'], columnWidths: { symbol: 240 } });
+
+      expect(widthOf(service.fullListOfColumns(), 'symbol')).toBe(240);
+    });
+
+    it('restores an empty selection', () => {
+      const service = hydrate({ displayedColumns: [], columnWidths: {} });
+
+      expect(service.columnsToDisplay()).toEqual([]);
+    });
+
+    it('drops unknown column names', () => {
+      const service = hydrate({ displayedColumns: ['name', 'not-a-column'], columnWidths: {} });
+
+      expect(columnNames(service.columnsToDisplay())).toEqual(['name']);
+    });
+
+    it('drops duplicated column names', () => {
+      const service = hydrate({ displayedColumns: ['name', 'name'], columnWidths: {} });
+
+      expect(columnNames(service.columnsToDisplay())).toEqual(['name']);
+    });
+
+    it('ignores invalid widths', () => {
+      const service = hydrate({
+        displayedColumns: ['name', 'symbol'],
+        columnWidths: { name: 'wide', symbol: -20 },
+      });
+
+      expect(widthOf(service.columnsToDisplay(), 'name')).toBe(NAME_COLUMN.width);
+      expect(widthOf(service.columnsToDisplay(), 'symbol')).toBe(SYMBOL_COLUMN.width);
+    });
+
+    it.each([null, 'not an object', 42])(
+      'falls back to the defaults for the payload %s',
+      (value) => {
+        const service = hydrate(value);
+
+        expect(service.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
+      },
+    );
+
+    it('falls back to the default columns when the selection is missing', () => {
+      const service = hydrate({ columnWidths: { name: 240 } });
+
+      expect(columnNames(service.columnsToDisplay())).toEqual(columnNames(DEFAULT_COLUMNS));
+      expect(widthOf(service.columnsToDisplay(), 'name')).toBe(240);
+    });
+
+    it('falls back to the default widths when the widths are missing', () => {
+      const service = hydrate({ displayedColumns: ['name'] });
+
+      expect(widthOf(service.columnsToDisplay(), 'name')).toBe(NAME_COLUMN.width);
+    });
+
+    it('falls back to the defaults when the stored value is not valid JSON', () => {
+      const service = createService(createStorage({ [TABLE_STATE_STORAGE_KEY]: '{ not json' }));
+
+      expect(service.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
+    });
+  });
+
+  describe('without storage', () => {
+    it('still exposes the default state', () => {
+      TestBed.configureTestingModule({
+        providers: [{ provide: DOCUMENT, useValue: { defaultView: undefined } }],
+      });
+      const service = TestBed.inject(AppState);
+
+      expect(service.columnsToDisplay()).toEqual(DEFAULT_COLUMNS);
+      expect(() => {
+        service.setColumnWidth('name', 240);
+        TestBed.tick();
+      }).not.toThrow();
+    });
   });
 });

--- a/src/app/services/app-state.ts
+++ b/src/app/services/app-state.ts
@@ -1,0 +1,4 @@
+import { Service } from '@angular/core';
+
+@Service()
+export class AppState {}

--- a/src/app/services/app-state.ts
+++ b/src/app/services/app-state.ts
@@ -1,9 +1,16 @@
-import { Service, computed, effect, inject, signal } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { DestroyRef, Service, computed, effect, inject, signal } from '@angular/core';
 import { ColumnDefinition } from '../interfaces/column-definition';
 import { ALL_COLUMNS, DEFAULT_COLUMNS, FULL_LIST_OF_COLUMNS } from '../interfaces/columns';
 import { LocalStorage } from './local-storage';
 
 export const TABLE_STATE_STORAGE_KEY = 'example-angular-app.table-state';
+
+/**
+ * How long the state has to settle before it is written to local storage. Drag resizing emits a
+ * new width on every pointer move, so writes are coalesced instead of hitting storage per frame.
+ */
+export const PERSIST_DEBOUNCE_MS = 250;
 
 /** Shape written to local storage. Only user owned state is persisted. */
 export interface PersistedTableState {
@@ -31,7 +38,9 @@ function isValidWidth(width: unknown): width is number {
 @Service()
 export class AppState {
   private readonly localStorage = inject(LocalStorage);
+  private readonly document = inject(DOCUMENT);
   private readonly restoredState = this.restoreTableState();
+  private pendingState: PersistedTableState | null = null;
 
   private readonly columnCatalog = signal(
     this.createColumnCatalog(this.restoredState?.columnWidths ?? {}),
@@ -74,14 +83,37 @@ export class AppState {
   });
 
   constructor() {
-    effect(() => {
-      const state: PersistedTableState = {
+    effect((onCleanup) => {
+      this.pendingState = {
         displayedColumns: this.displayedColumnNames(),
         columnWidths: this.columnWidthOverrides(),
       };
 
-      this.localStorage.write(TABLE_STATE_STORAGE_KEY, state);
+      // Each new state cancels the pending write, so a burst of updates results in a single
+      // write once the state settles. The cleanup also runs when the service is destroyed.
+      const pendingWrite = setTimeout(() => {
+        this.persistPendingState();
+      }, PERSIST_DEBOUNCE_MS);
+
+      onCleanup(() => {
+        clearTimeout(pendingWrite);
+      });
     });
+
+    const view = this.document.defaultView;
+
+    if (view) {
+      // A reload, a tab close or a navigation can happen before the debounce elapses, so write
+      // whatever is still pending while the page is being torn down.
+      const flush = () => {
+        this.persistPendingState();
+      };
+
+      view.addEventListener('pagehide', flush);
+      inject(DestroyRef).onDestroy(() => {
+        view.removeEventListener('pagehide', flush);
+      });
+    }
   }
 
   /** Replaces the displayed columns, ignoring unknown and duplicated columns. */
@@ -116,6 +148,15 @@ export class AppState {
 
       return updatedCatalog;
     });
+  }
+
+  private persistPendingState(): void {
+    if (this.pendingState === null) {
+      return;
+    }
+
+    this.localStorage.write(TABLE_STATE_STORAGE_KEY, this.pendingState);
+    this.pendingState = null;
   }
 
   private createColumnCatalog(columnWidths: Record<string, number>): Map<string, ColumnDefinition> {

--- a/src/app/services/app-state.ts
+++ b/src/app/services/app-state.ts
@@ -1,4 +1,186 @@
-import { Service } from '@angular/core';
+import { Service, computed, effect, inject, signal } from '@angular/core';
+import { ColumnDefinition } from '../interfaces/column-definition';
+import { ALL_COLUMNS, DEFAULT_COLUMNS, FULL_LIST_OF_COLUMNS } from '../interfaces/columns';
+import { LocalStorage } from './local-storage';
 
+export const TABLE_STATE_STORAGE_KEY = 'example-angular-app.table-state';
+
+/** Shape written to local storage. Only user owned state is persisted. */
+export interface PersistedTableState {
+  displayedColumns: string[];
+  columnWidths: Record<string, number>;
+}
+
+interface RestoredTableState {
+  displayedColumns: string[] | null;
+  columnWidths: Record<string, number>;
+}
+
+function isValidWidth(width: unknown): width is number {
+  return typeof width === 'number' && Number.isFinite(width) && width > 0;
+}
+
+/**
+ * Holds the state the user can change while using the app and keeps it in local storage so a
+ * page reload restores it.
+ *
+ * Column widths live on the `ColumnDefinition` objects of a catalog that covers every known
+ * column, not only the displayed ones. Hiding a column therefore keeps the width the user last
+ * left it at, and re-displaying the column brings that width back.
+ */
 @Service()
-export class AppState {}
+export class AppState {
+  private readonly localStorage = inject(LocalStorage);
+  private readonly restoredState = this.restoreTableState();
+
+  private readonly columnCatalog = signal(
+    this.createColumnCatalog(this.restoredState?.columnWidths ?? {}),
+  );
+  private readonly displayedColumnNames = signal(
+    this.restoredState?.displayedColumns ?? DEFAULT_COLUMNS.map((column) => column.name),
+  );
+
+  /** Displayed columns, in display order, carrying their current widths. */
+  readonly columnsToDisplay = computed(() => {
+    const catalog = this.columnCatalog();
+
+    return this.displayedColumnNames()
+      .map((name) => catalog.get(name))
+      .filter((column) => column !== undefined);
+  });
+
+  /** Every column offered by the column chooser, carrying its current width. */
+  readonly fullListOfColumns = computed(() => {
+    const catalog = this.columnCatalog();
+
+    return FULL_LIST_OF_COLUMNS.map((column) => catalog.get(column.name) ?? column);
+  });
+
+  // Only widths that differ from the built-in defaults are persisted, so changing a default in
+  // code still reaches users who never resized that column.
+  private readonly columnWidthOverrides = computed(() => {
+    const catalog = this.columnCatalog();
+    const overrides: Record<string, number> = {};
+
+    for (const column of ALL_COLUMNS) {
+      const currentWidth = catalog.get(column.name)?.width;
+
+      if (currentWidth !== undefined && currentWidth !== column.width) {
+        overrides[column.name] = currentWidth;
+      }
+    }
+
+    return overrides;
+  });
+
+  constructor() {
+    effect(() => {
+      const state: PersistedTableState = {
+        displayedColumns: this.displayedColumnNames(),
+        columnWidths: this.columnWidthOverrides(),
+      };
+
+      this.localStorage.write(TABLE_STATE_STORAGE_KEY, state);
+    });
+  }
+
+  /** Replaces the displayed columns, ignoring unknown and duplicated columns. */
+  setColumnsToDisplay(columns: ColumnDefinition[]): void {
+    const catalog = this.columnCatalog();
+    const names: string[] = [];
+
+    for (const column of columns) {
+      if (catalog.has(column.name) && !names.includes(column.name)) {
+        names.push(column.name);
+      }
+    }
+
+    this.displayedColumnNames.set(names);
+  }
+
+  /** Stores the width of a column, whether or not the column is currently displayed. */
+  setColumnWidth(name: string, width: number): void {
+    if (!isValidWidth(width)) {
+      return;
+    }
+
+    this.columnCatalog.update((catalog) => {
+      const column = catalog.get(name);
+
+      if (!column || column.width === width) {
+        return catalog;
+      }
+
+      const updatedCatalog = new Map(catalog);
+      updatedCatalog.set(name, { ...column, width });
+
+      return updatedCatalog;
+    });
+  }
+
+  private createColumnCatalog(columnWidths: Record<string, number>): Map<string, ColumnDefinition> {
+    return new Map(
+      ALL_COLUMNS.map((column) => {
+        const width = columnWidths[column.name];
+
+        return [column.name, isValidWidth(width) ? { ...column, width } : column];
+      }),
+    );
+  }
+
+  private restoreTableState(): RestoredTableState | null {
+    return this.localStorage.read(TABLE_STATE_STORAGE_KEY, (value) => this.parseTableState(value));
+  }
+
+  private parseTableState(value: unknown): RestoredTableState | null {
+    if (typeof value !== 'object' || value === null) {
+      return null;
+    }
+
+    const state = value as Partial<Record<keyof PersistedTableState, unknown>>;
+
+    return {
+      displayedColumns: this.parseDisplayedColumns(state.displayedColumns),
+      columnWidths: this.parseColumnWidths(state.columnWidths),
+    };
+  }
+
+  private parseDisplayedColumns(value: unknown): string[] | null {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const knownColumnNames = new Set(ALL_COLUMNS.map((column) => column.name));
+    const displayedColumns: string[] = [];
+
+    for (const name of value as unknown[]) {
+      if (
+        typeof name === 'string' &&
+        knownColumnNames.has(name) &&
+        !displayedColumns.includes(name)
+      ) {
+        displayedColumns.push(name);
+      }
+    }
+
+    return displayedColumns;
+  }
+
+  private parseColumnWidths(value: unknown): Record<string, number> {
+    if (typeof value !== 'object' || value === null) {
+      return {};
+    }
+
+    const widths: Record<string, number> = {};
+
+    for (const column of ALL_COLUMNS) {
+      const width = (value as Record<string, unknown>)[column.name];
+
+      if (isValidWidth(width)) {
+        widths[column.name] = width;
+      }
+    }
+
+    return widths;
+  }
+}

--- a/src/app/services/local-storage.spec.ts
+++ b/src/app/services/local-storage.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { LocalStorage } from './local-storage';
+
+describe('LocalStorage', () => {
+  let service: LocalStorage;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LocalStorage);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/local-storage.spec.ts
+++ b/src/app/services/local-storage.spec.ts
@@ -163,5 +163,28 @@ describe('LocalStorage', () => {
       }).not.toThrow();
       expect(storage.getItem('user')).toBeNull();
     });
+
+    it.each([
+      ['undefined', undefined],
+      ['a function', vi.fn()],
+      ['a symbol', Symbol('token')],
+    ])('skips the write for %s, which has no JSON representation', (_label, value) => {
+      const storage = createStorage();
+      const service = createService({ localStorage: storage });
+
+      service.write('user', value);
+
+      expect(storage.getItem('user')).toBeNull();
+    });
+
+    it('leaves an existing value untouched when the new value cannot be serialized', () => {
+      const storage = createStorage();
+      const service = createService({ localStorage: storage });
+      service.write('user', { name: 'Ada' });
+
+      service.write('user', undefined);
+
+      expect(storage.getItem('user')).toBe('{"name":"Ada"}');
+    });
   });
 });

--- a/src/app/services/local-storage.spec.ts
+++ b/src/app/services/local-storage.spec.ts
@@ -151,5 +151,17 @@ describe('LocalStorage', () => {
         service.write('user', { name: 'Ada' });
       }).not.toThrow();
     });
+
+    it('ignores values that cannot be serialized', () => {
+      const storage = createStorage();
+      const service = createService({ localStorage: storage });
+      const circularValue: Record<string, unknown> = {};
+      circularValue['self'] = circularValue;
+
+      expect(() => {
+        service.write('user', circularValue);
+      }).not.toThrow();
+      expect(storage.getItem('user')).toBeNull();
+    });
   });
 });

--- a/src/app/services/local-storage.spec.ts
+++ b/src/app/services/local-storage.spec.ts
@@ -1,15 +1,155 @@
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 import { LocalStorage } from './local-storage';
 
-describe('LocalStorage', () => {
-  let service: LocalStorage;
+function createStorage(entries: Record<string, string> = {}): Storage {
+  const values = new Map(Object.entries(entries));
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(LocalStorage);
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+}
+
+function createService(defaultView: unknown): LocalStorage {
+  TestBed.configureTestingModule({
+    providers: [{ provide: DOCUMENT, useValue: { defaultView } }],
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  return TestBed.inject(LocalStorage);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+describe('LocalStorage', () => {
+  describe('with a working storage', () => {
+    let storage: Storage;
+    let service: LocalStorage;
+
+    beforeEach(() => {
+      storage = createStorage();
+      service = createService({ localStorage: storage });
+    });
+
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+
+    it('returns null when nothing is stored under the key', () => {
+      expect(service.read('missing', asString)).toBeNull();
+    });
+
+    it('parses the stored JSON value before handing it to the parser', () => {
+      storage.setItem('user', JSON.stringify({ name: 'Ada' }));
+      const parse = vi.fn((value: unknown) => value);
+
+      const result = service.read('user', parse);
+
+      expect(parse).toHaveBeenCalledWith({ name: 'Ada' });
+      expect(result).toEqual({ name: 'Ada' });
+    });
+
+    it('returns null when the stored value is not valid JSON', () => {
+      storage.setItem('broken', '{ not json');
+
+      expect(service.read('broken', asString)).toBeNull();
+    });
+
+    it('returns null when the parser rejects the stored value', () => {
+      storage.setItem('count', JSON.stringify(42));
+
+      expect(service.read('count', asString)).toBeNull();
+    });
+
+    it('serializes values when writing', () => {
+      service.write('user', { name: 'Ada' });
+
+      expect(storage.getItem('user')).toBe('{"name":"Ada"}');
+    });
+
+    it('reads back what it wrote', () => {
+      service.write('columns', ['name', 'symbol']);
+
+      expect(service.read('columns', (value) => value as string[])).toEqual(['name', 'symbol']);
+    });
+
+    it('removes a stored value', () => {
+      service.write('user', { name: 'Ada' });
+      service.remove('user');
+
+      expect(storage.getItem('user')).toBeNull();
+    });
+
+    it('rethrows errors raised by the parser', () => {
+      storage.setItem('user', '"Ada"');
+
+      expect(() =>
+        service.read('user', () => {
+          throw new TypeError('Parser blew up');
+        }),
+      ).toThrow(TypeError);
+    });
+  });
+
+  describe('when storage is unavailable', () => {
+    it('degrades to no-ops when there is no window', () => {
+      const service = createService(undefined);
+
+      expect(service.read('user', asString)).toBeNull();
+      expect(() => {
+        service.write('user', { name: 'Ada' });
+      }).not.toThrow();
+      expect(() => {
+        service.remove('user');
+      }).not.toThrow();
+    });
+
+    it('degrades to no-ops when accessing storage throws', () => {
+      const service = createService({
+        get localStorage(): Storage {
+          throw new Error('Storage is disabled');
+        },
+      });
+
+      expect(service.read('user', asString)).toBeNull();
+      expect(() => {
+        service.write('user', { name: 'Ada' });
+      }).not.toThrow();
+    });
+
+    it('ignores read failures', () => {
+      const storage = createStorage();
+      vi.spyOn(storage, 'getItem').mockImplementation(() => {
+        throw new Error('Read denied');
+      });
+      const service = createService({ localStorage: storage });
+
+      expect(service.read('user', asString)).toBeNull();
+    });
+
+    it('ignores write failures such as an exceeded quota', () => {
+      const storage = createStorage();
+      vi.spyOn(storage, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      const service = createService({ localStorage: storage });
+
+      expect(() => {
+        service.write('user', { name: 'Ada' });
+      }).not.toThrow();
+    });
   });
 });

--- a/src/app/services/local-storage.ts
+++ b/src/app/services/local-storage.ts
@@ -1,0 +1,4 @@
+import { Service } from '@angular/core';
+
+@Service()
+export class LocalStorage {}

--- a/src/app/services/local-storage.ts
+++ b/src/app/services/local-storage.ts
@@ -38,10 +38,10 @@ export class LocalStorage {
 
   /** JSON serializes `value` and stores it under `key`. */
   write(key: string, value: unknown): void {
-    const serializedValue = JSON.stringify(value);
-
     this.withStorage((storage) => {
-      storage.setItem(key, serializedValue);
+      // Serialization happens inside the guard so a value that cannot be serialized (a circular
+      // reference, a bigint) degrades to a no-op instead of throwing at the caller.
+      storage.setItem(key, JSON.stringify(value));
 
       return true;
     });
@@ -62,8 +62,9 @@ export class LocalStorage {
 
       return storage ? operation(storage) : null;
     } catch {
-      // Storage can throw when it is disabled by the browser or when a write exceeds the
-      // available quota. Persistence is a convenience here, so failures are ignored.
+      // Storage can throw when it is disabled by the browser, when a write exceeds the available
+      // quota, or when a value cannot be serialized. Persistence is a convenience here, so
+      // failures are ignored.
       return null;
     }
   }

--- a/src/app/services/local-storage.ts
+++ b/src/app/services/local-storage.ts
@@ -1,4 +1,70 @@
-import { Service } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Service, inject } from '@angular/core';
 
+/**
+ * Thin, failure tolerant wrapper around the browser's local storage.
+ *
+ * Every operation degrades to a no-op when storage is unavailable (server side rendering,
+ * private browsing modes, disabled cookies) or when the browser throws while reading or
+ * writing (for example `QuotaExceededError`), so callers never have to guard their state.
+ */
 @Service()
-export class LocalStorage {}
+export class LocalStorage {
+  private readonly document = inject(DOCUMENT);
+
+  /**
+   * Reads and JSON parses the value stored under `key`. The raw parsed value is handed to
+   * `parse` so the caller can validate it before trusting persisted data.
+   */
+  read<T>(key: string, parse: (value: unknown) => T | null): T | null {
+    const rawValue = this.withStorage((storage) => storage.getItem(key));
+
+    if (rawValue === null) {
+      return null;
+    }
+
+    let parsedValue: unknown;
+
+    try {
+      parsedValue = JSON.parse(rawValue);
+    } catch {
+      // The stored value is not valid JSON, for example because it was written by an older
+      // version of the app or by another tool. Treat it as if nothing was stored.
+      return null;
+    }
+
+    return parse(parsedValue);
+  }
+
+  /** JSON serializes `value` and stores it under `key`. */
+  write(key: string, value: unknown): void {
+    const serializedValue = JSON.stringify(value);
+
+    this.withStorage((storage) => {
+      storage.setItem(key, serializedValue);
+
+      return true;
+    });
+  }
+
+  /** Removes the value stored under `key`. */
+  remove(key: string): void {
+    this.withStorage((storage) => {
+      storage.removeItem(key);
+
+      return true;
+    });
+  }
+
+  private withStorage<T>(operation: (storage: Storage) => T | null): T | null {
+    try {
+      const storage = this.document.defaultView?.localStorage;
+
+      return storage ? operation(storage) : null;
+    } catch {
+      // Storage can throw when it is disabled by the browser or when a write exceeds the
+      // available quota. Persistence is a convenience here, so failures are ignored.
+      return null;
+    }
+  }
+}

--- a/src/app/services/local-storage.ts
+++ b/src/app/services/local-storage.ts
@@ -41,7 +41,16 @@ export class LocalStorage {
     this.withStorage((storage) => {
       // Serialization happens inside the guard so a value that cannot be serialized (a circular
       // reference, a bigint) degrades to a no-op instead of throwing at the caller.
-      storage.setItem(key, JSON.stringify(value));
+      const serializedValue = JSON.stringify(value);
+
+      // `JSON.stringify` returns undefined, rather than throwing, for values without a JSON
+      // representation (undefined, functions, symbols). Writing that would store the literal
+      // string "undefined", so skip the write and leave any existing value untouched.
+      if (serializedValue === undefined) {
+        return null;
+      }
+
+      storage.setItem(key, serializedValue);
 
       return true;
     });

--- a/src/app/services/url-cache.ts
+++ b/src/app/services/url-cache.ts
@@ -1,9 +1,7 @@
-import { Injectable, inject } from '@angular/core';
+import { Service, inject } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class UrlCache {
   private readonly domSanitizer = inject(DomSanitizer);
 

--- a/tests/mat-table.spec.ts
+++ b/tests/mat-table.spec.ts
@@ -117,4 +117,33 @@ test.describe('Mat table tab', () => {
     await expect(page.locator('td.mat-column-atomic_mass')).not.toBeAttached();
     await expect(page.locator('th.mat-column-name')).toBeAttached();
   });
+
+  test('restores the selected columns after a reload', async ({ page }) => {
+    await page.locator('[data-testid="column-chooser-trigger"]').click();
+    const appearanceCheckbox = page.locator('.cdk-overlay-container mat-checkbox', {
+      hasText: 'Appearance',
+    });
+    await expect(appearanceCheckbox).toBeVisible();
+    await appearanceCheckbox.click();
+    await expect(page.locator('th.mat-column-appearance')).toBeAttached();
+
+    await page.reload();
+
+    await expect(page.locator('th.mat-column-appearance')).toBeAttached();
+    await expect(page.locator('th.mat-column-name')).toBeAttached();
+  });
+
+  test('restores a resized column width after a reload', async ({ page }) => {
+    const nameHeader = page.locator('th.mat-column-name');
+    await expect(nameHeader).toHaveCSS('width', '150px');
+
+    // The resize handle is keyboard operable and moves in fixed 16px steps.
+    await nameHeader.locator('.column-resize-handle').focus();
+    await page.keyboard.press('ArrowRight');
+    await expect(nameHeader).toHaveCSS('width', '166px');
+
+    await page.reload();
+
+    await expect(page.locator('th.mat-column-name')).toHaveCSS('width', '166px');
+  });
 });


### PR DESCRIPTION
## Summary

The `MatTable` column picker and column widths reset on every page load. This adds an
`AppState` service that owns that state and a `LocalStorage` service that persists it, so a
reload restores exactly what the user had.

Column widths now live on the `ColumnDefinition` objects themselves, held in an `AppState`
catalog of *every* known column — not just the displayed ones. Hiding a column therefore keeps
the width the user left it at, and re-displaying the column brings that width back.

## Changes

**New: `services/local-storage.ts`**
- Failure-tolerant JSON wrapper around `window.localStorage`: `read<T>(key, parse)`, `write`, `remove`.
- Reached through `DOCUMENT.defaultView`, and every operation degrades to a no-op when storage is
  absent, disabled, or throws (`QuotaExceededError`, opaque-origin `SecurityError`). Callers never
  have to guard their state.

**New: `services/app-state.ts`**
- `columnCatalog` signal: every known column as a `ColumnDefinition` carrying its current width.
- `displayedColumnNames` signal → `columnsToDisplay` / `fullListOfColumns` computeds.
- `setColumnsToDisplay()` drops unknown and duplicated columns; `setColumnWidth()` rejects
  non-finite/non-positive widths.
- Hydrates from storage with validation against the known columns (malformed payloads,
  unknown names, and bad widths fall back to defaults), and persists via an `effect`.
  Only widths that *differ* from the code defaults are stored, so changing a default in code
  still reaches users who never resized that column.

**New: `interfaces/columns.ts`**
- All column constants moved out of `mat-table.ts` so services can use them without an import
  cycle (`import/no-cycle` is enforced). Adds `ALL_COLUMNS` (chooser list + `source`).

**Changed: `MatTable`**
- Dropped the local `columnWidths` signal and the `columnWidth()` helper; the component now
  delegates to `AppState` and the template binds `column.width` directly.
- `columnsToRender` stays a `string[]` — Material's `matHeaderRowDef`/`matRowDef` require plain
  column names.

**Also included (pre-existing commits on this branch)**
- `UrlCache` migrated from `@Injectable({providedIn: 'root'})` to the v22 `@Service()` decorator.
- `app.spec.ts` stubs the page templates via `TestBed.overrideTemplate`; those specs only assert
  route→component resolution, and booting `MatTable` + a live iframe was the slowest work in the
  suite and flaked against the 5s default timeout under parallel load.
- Dev-dependency bumps in `package-lock.json` (`baseline-browser-mapping`, `ip-address`).
- `AGENTS.md` repo map refreshed and instruction files re-synced.

## Testing

- `npm run test:unit` — 222 passing; new `local-storage.spec.ts` and `app-state.spec.ts` cover
  hydration, validation, persistence, hidden-column width memory, and unavailable/throwing storage
  (services at 100% line coverage). `mat-table.spec.ts` updated for the new API and stubs
  `LocalStorage` to stay isolated.
- `npm run test:e2e` — 60 passing across Chromium/Firefox/WebKit, including two new specs proving
  column selection and a keyboard-resized width (150px → 166px) survive `page.reload()`.
- `npm run lint`, `npm run prettier:test`, `npm run build`, `npm run sync:agent-instructions:check` all clean.

## Notes for reviewers

- Persisted payload: `{ displayedColumns: string[], columnWidths: Record<string, number> }` under
  the key `example-angular-app.table-state`.
- An empty column selection is a legitimate persisted state and is preserved on reload; only a
  missing or malformed `displayedColumns` falls back to `DEFAULT_COLUMNS`.