### PR TITLE
Keep mat-sort arrow visible by default

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -125,3 +125,21 @@ body {
   outline: 2px solid var(--mat-sys-primary, #3f51b5);
   outline-offset: -2px;
 }
+
+// Angular Material hides the `mat-sort-header` arrow (opacity: 0) until the header
+// is hovered or focused, which makes sortable columns hard to discover. Keep the
+// arrow visible at rest using the same opacity Material applies on hover; sorted
+// headers keep their full-opacity arrow. MatSortHeader renders the arrow inside
+// its own view, so this override cannot live in an encapsulated component style.
+.mat-sort-header .mat-sort-header-container:not(.mat-sort-header-sorted) .mat-sort-header-arrow {
+  opacity: 0.54;
+}
+
+// Clearing a sort plays a fade-out animation that leaves the arrow invisible until
+// focus moves elsewhere. Skip it so the arrow returns straight to its resting state.
+.mat-sort-header .mat-sort-header-recently-cleared-ascending .mat-sort-header-arrow,
+.mat-sort-header .mat-sort-header-recently-cleared-descending .mat-sort-header-arrow {
+  animation: none;
+  transform: none;
+  opacity: 0.54;
+}

--- a/tests/mat-table.spec.ts
+++ b/tests/mat-table.spec.ts
@@ -93,6 +93,20 @@ test.describe('Mat table tab', () => {
     await expect(getRow(page, 1).locator('td.mat-column-name')).toContainText('Zinc');
   });
 
+  test('keeps the sort arrow visible without hovering the header', async ({ page }) => {
+    const nameArrow = page.locator('th.mat-column-name .mat-sort-header-arrow');
+    await expect(nameArrow).toHaveCSS('opacity', '0.54');
+
+    // Sorted headers show the arrow at full opacity...
+    await page.locator('th.mat-column-name').click();
+    await expect(nameArrow).toHaveCSS('opacity', '1');
+
+    // ...and clearing the sort returns it to the resting visible state.
+    await page.locator('th.mat-column-name').click();
+    await page.locator('th.mat-column-name').click();
+    await expect(nameArrow).toHaveCSS('opacity', '0.54');
+  });
+
   test('changes page size using paginator options', async ({ page }) => {
     await expect(getDataRows(page)).toHaveCount(25);
     await page.locator('mat-paginator .mat-mdc-paginator-touch-target').click();


### PR DESCRIPTION
Add global Angular Material sort-header style overrides so unsorted headers keep a visible arrow (opacity 0.54) and recently cleared sort states don’t fade the arrow out. Also add a Playwright test that verifies arrow opacity at rest, full opacity when sorted, and restored visibility after clearing sort.