### PR TITLE
Add per-column table filters with overlay UI

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,13 +16,15 @@ module.exports = defineConfig([
     '.angular/',
     '.codacy/',
     '.github/instructions/',
+    '.husky/',
+    '.idea/',
     'coverage/',
     'dist/',
+    'node_modules/',
     'playwright-report/',
     'test-results/',
     'package-lock.json',
-    // Generated agent instruction files (source of truth: agent-instructions/source.md)
-    'AGENTS.md',
+    // Generated agent instruction files (source of truth: AGENTS.md)
     '.claude/CLAUDE.md',
     '.gemini/GEMINI.md',
     '.github/copilot-instructions.md',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5754,9 +5754,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
-      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
+      "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7423,9 +7423,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright/node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7809,9 +7809,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
-      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15174,9 +15174,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/app/components/mat-table/column-filter/column-filter.html
+++ b/src/app/components/mat-table/column-filter/column-filter.html
@@ -6,7 +6,7 @@
   [attr.aria-label]="triggerLabel()"
   [attr.aria-expanded]="isOpen()"
   [attr.data-testid]="'column-filter-trigger-' + column().name"
-  aria-haspopup="true"
+  aria-haspopup="dialog"
   (click)="toggle()"
   cdkOverlayOrigin
   #origin="cdkOverlayOrigin"
@@ -24,6 +24,9 @@
   <mat-card
     class="column-filter-card"
     appearance="outlined"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-label]="dialogLabel()"
     cdkTrapFocus
     [cdkTrapFocusAutoCapture]="true"
     (keydown.escape)="close()"

--- a/src/app/components/mat-table/column-filter/column-filter.html
+++ b/src/app/components/mat-table/column-filter/column-filter.html
@@ -1,0 +1,50 @@
+<button
+  mat-icon-button
+  type="button"
+  class="column-filter-trigger"
+  [class.column-filter-trigger-active]="hasSelection()"
+  [attr.aria-label]="triggerLabel()"
+  [attr.aria-expanded]="isOpen()"
+  [attr.data-testid]="'column-filter-trigger-' + column().name"
+  aria-haspopup="true"
+  (click)="toggle()"
+  cdkOverlayOrigin
+  #origin="cdkOverlayOrigin"
+>
+  <mat-icon fontIcon="filter_alt" aria-hidden="true" />
+</button>
+<ng-template
+  cdkConnectedOverlay
+  [cdkConnectedOverlayOrigin]="origin"
+  [cdkConnectedOverlayOpen]="isOpen()"
+  [cdkConnectedOverlayHasBackdrop]="true"
+  (backdropClick)="close()"
+  (detach)="close()"
+>
+  <mat-card
+    class="column-filter-card"
+    appearance="outlined"
+    cdkTrapFocus
+    [cdkTrapFocusAutoCapture]="true"
+    (keydown.escape)="close()"
+  >
+    <mat-card-content class="column-filter-content">
+      <mat-form-field class="column-filter-field">
+        <mat-label>{{ column().displayName }}</mat-label>
+        <mat-select
+          multiple
+          [value]="selectedValues()"
+          [attr.data-testid]="'column-filter-select-' + column().name"
+          (valueChange)="selectedValues.set($event)"
+        >
+          @for (option of options(); track option) {
+            <mat-option [value]="option">{{ option }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+      <button mat-button type="button" [disabled]="!hasSelection()" (click)="clear()">
+        Clear filter
+      </button>
+    </mat-card-content>
+  </mat-card>
+</ng-template>

--- a/src/app/components/mat-table/column-filter/column-filter.scss
+++ b/src/app/components/mat-table/column-filter/column-filter.scss
@@ -1,0 +1,22 @@
+.column-filter-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 260px;
+  padding: 10px;
+  margin: 0;
+}
+
+.column-filter-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding-bottom: 0;
+}
+
+.column-filter-field {
+  width: 100%;
+}
+
+.column-filter-trigger-active {
+  color: var(--mat-sys-primary, #3f51b5);
+}

--- a/src/app/components/mat-table/column-filter/column-filter.spec.ts
+++ b/src/app/components/mat-table/column-filter/column-filter.spec.ts
@@ -90,6 +90,10 @@ describe('ColumnFilter', () => {
       expect(trigger().getAttribute('data-testid')).toBe('column-filter-trigger-phase');
     });
 
+    it('announces that the trigger opens a dialog', () => {
+      expect(trigger().getAttribute('aria-haspopup')).toBe('dialog');
+    });
+
     it('reports the number of selected values in the trigger label', () => {
       fixture.componentRef.setInput('selectedValues', ['Gas', 'Solid']);
       fixture.detectChanges();
@@ -138,6 +142,24 @@ describe('ColumnFilter', () => {
       openOverlay();
 
       expect(overlayContainerElement.querySelector('mat-label')?.textContent?.trim()).toBe('Phase');
+    });
+
+    it('exposes the card as a labelled modal dialog', () => {
+      openOverlay();
+
+      const card = overlayContainerElement.querySelector('mat-card.column-filter-card');
+
+      expect(card?.getAttribute('role')).toBe('dialog');
+      expect(card?.getAttribute('aria-modal')).toBe('true');
+      expect(card?.getAttribute('aria-label')).toBe('Filter Phase column');
+    });
+
+    it('keeps the dialog label free of the selection count carried by the trigger', () => {
+      fixture.componentRef.setInput('selectedValues', ['Gas']);
+      openOverlay();
+
+      expect(component.dialogLabel()).toBe('Filter Phase column');
+      expect(component.triggerLabel()).toBe('Filter Phase column, 1 selected');
     });
 
     it('shows the current selection in the select', () => {

--- a/src/app/components/mat-table/column-filter/column-filter.spec.ts
+++ b/src/app/components/mat-table/column-filter/column-filter.spec.ts
@@ -1,0 +1,209 @@
+import { CdkTrapFocus } from '@angular/cdk/a11y';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSelect } from '@angular/material/select';
+import { By } from '@angular/platform-browser';
+import { ColumnDefinition } from '../../../interfaces/column-definition';
+import { ColumnFilter } from './column-filter';
+
+const PHASE_COLUMN: ColumnDefinition = {
+  name: 'phase',
+  displayName: 'Phase',
+  isSortable: true,
+  isFilterable: true,
+  width: 150,
+};
+
+describe('ColumnFilter', () => {
+  let component: ColumnFilter;
+  let fixture: ComponentFixture<ColumnFilter>;
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+
+  function trigger(): HTMLButtonElement {
+    return fixture.debugElement.query(By.css('button.column-filter-trigger'))
+      .nativeElement as HTMLButtonElement;
+  }
+
+  function openOverlay(): void {
+    trigger().click();
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ColumnFilter],
+    }).compileComponents();
+
+    overlayContainer = TestBed.inject(OverlayContainer);
+    overlayContainerElement = overlayContainer.getContainerElement();
+    fixture = TestBed.createComponent(ColumnFilter);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('column', PHASE_COLUMN);
+    fixture.componentRef.setInput('options', ['Gas', 'Liquid', 'Solid']);
+    fixture.componentRef.setInput('selectedValues', []);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Trigger', () => {
+    it('keeps the overlay closed until the trigger is used', () => {
+      expect(component.isOpen()).toBeFalsy();
+      expect(overlayContainerElement.querySelector('.column-filter-card')).toBeNull();
+      expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('opens and closes the overlay from the trigger', () => {
+      openOverlay();
+
+      expect(component.isOpen()).toBeTruthy();
+      expect(overlayContainerElement.querySelector('.column-filter-card')).toBeTruthy();
+      expect(trigger().getAttribute('aria-expanded')).toBe('true');
+
+      trigger().click();
+      fixture.detectChanges();
+
+      expect(component.isOpen()).toBeFalsy();
+      expect(overlayContainerElement.querySelector('.column-filter-card')).toBeNull();
+    });
+
+    it('closes the overlay when the backdrop is clicked', () => {
+      openOverlay();
+
+      const backdrop = overlayContainerElement.querySelector('.cdk-overlay-backdrop');
+      expect(backdrop).toBeTruthy();
+      (backdrop as HTMLElement).click();
+      fixture.detectChanges();
+
+      expect(component.isOpen()).toBeFalsy();
+    });
+
+    it('labels the trigger with the column it filters', () => {
+      expect(trigger().getAttribute('aria-label')).toBe('Filter Phase column');
+      expect(trigger().getAttribute('data-testid')).toBe('column-filter-trigger-phase');
+    });
+
+    it('reports the number of selected values in the trigger label', () => {
+      fixture.componentRef.setInput('selectedValues', ['Gas', 'Solid']);
+      fixture.detectChanges();
+
+      expect(trigger().getAttribute('aria-label')).toBe('Filter Phase column, 2 selected');
+    });
+
+    it('marks the trigger as active only while values are selected', () => {
+      expect(trigger().classList).not.toContain('column-filter-trigger-active');
+
+      fixture.componentRef.setInput('selectedValues', ['Gas']);
+      fixture.detectChanges();
+
+      expect(component.hasSelection()).toBeTruthy();
+      expect(trigger().classList).toContain('column-filter-trigger-active');
+    });
+
+    it('hides the icon from assistive technology', () => {
+      const icon = fixture.debugElement.query(By.css('button.column-filter-trigger mat-icon'));
+
+      expect(icon.attributes['aria-hidden']).toBe('true');
+      expect(icon.attributes['fontIcon']).toBe('filter_alt');
+    });
+  });
+
+  describe('Overlay content', () => {
+    it('renders a card holding a multiple select of the offered options', () => {
+      openOverlay();
+
+      const select = fixture.debugElement.query(By.directive(MatSelect))
+        .componentInstance as MatSelect;
+      select.open();
+      fixture.detectChanges();
+      const options = overlayContainerElement.querySelectorAll('mat-option');
+
+      expect(overlayContainerElement.querySelector('mat-card.column-filter-card')).toBeTruthy();
+      expect(select.multiple).toBeTruthy();
+      expect([...options].map((option) => option.textContent?.trim())).toEqual([
+        'Gas',
+        'Liquid',
+        'Solid',
+      ]);
+    });
+
+    it('labels the select with the column display name', () => {
+      openOverlay();
+
+      expect(overlayContainerElement.querySelector('mat-label')?.textContent?.trim()).toBe('Phase');
+    });
+
+    it('shows the current selection in the select', () => {
+      fixture.componentRef.setInput('selectedValues', ['Liquid']);
+      openOverlay();
+
+      const select = fixture.debugElement.query(By.directive(MatSelect))
+        .componentInstance as MatSelect;
+
+      expect(select.value).toEqual(['Liquid']);
+    });
+
+    it('emits the picked values when the select changes', () => {
+      const emitted: string[][] = [];
+      component.selectedValues.subscribe((values) => emitted.push(values));
+      openOverlay();
+
+      const select = fixture.debugElement.query(By.directive(MatSelect));
+      select.triggerEventHandler('valueChange', ['Gas', 'Solid']);
+
+      expect(emitted).toEqual([['Gas', 'Solid']]);
+      expect(component.selectedValues()).toEqual(['Gas', 'Solid']);
+    });
+
+    it('clears the selection from the clear button', () => {
+      fixture.componentRef.setInput('selectedValues', ['Gas']);
+      openOverlay();
+
+      const clearButton = [...overlayContainerElement.querySelectorAll('button')].find((button) =>
+        button.textContent?.includes('Clear filter'),
+      );
+      expect(clearButton?.disabled).toBeFalsy();
+      clearButton?.click();
+
+      expect(component.selectedValues()).toEqual([]);
+    });
+
+    it('disables the clear button while nothing is selected', () => {
+      openOverlay();
+
+      const clearButton = [...overlayContainerElement.querySelectorAll('button')].find((button) =>
+        button.textContent?.includes('Clear filter'),
+      );
+
+      expect(clearButton?.disabled).toBeTruthy();
+    });
+
+    it('closes the overlay when escape is pressed inside the card', () => {
+      openOverlay();
+
+      const card = overlayContainerElement.querySelector('mat-card.column-filter-card');
+      card?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(component.isOpen()).toBeFalsy();
+    });
+
+    it('traps focus in the overlay and returns it to the trigger when it closes', () => {
+      openOverlay();
+
+      // The trap only moves focus when the browser reports element geometry, which jsdom does not
+      // do, so the wiring is asserted here and the focus behaviour is covered by the e2e suite.
+      const trap = fixture.debugElement.query(By.directive(CdkTrapFocus));
+
+      expect(trap).toBeTruthy();
+      expect(trap.injector.get(CdkTrapFocus).autoCapture).toBeTruthy();
+    });
+  });
+});

--- a/src/app/components/mat-table/column-filter/column-filter.ts
+++ b/src/app/components/mat-table/column-filter/column-filter.ts
@@ -33,13 +33,13 @@ export class ColumnFilter {
 
   readonly isOpen = signal(false);
   readonly hasSelection = computed(() => this.selectedValues().length > 0);
+  readonly dialogLabel = computed(() => `Filter ${this.column().displayName} column`);
   readonly triggerLabel = computed(() => {
-    const displayName = this.column().displayName;
     const selectedCount = this.selectedValues().length;
 
     return selectedCount === 0
-      ? `Filter ${displayName} column`
-      : `Filter ${displayName} column, ${selectedCount} selected`;
+      ? this.dialogLabel()
+      : `${this.dialogLabel()}, ${selectedCount} selected`;
   });
 
   toggle(): void {

--- a/src/app/components/mat-table/column-filter/column-filter.ts
+++ b/src/app/components/mat-table/column-filter/column-filter.ts
@@ -1,0 +1,56 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Component, computed, input, model, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { ColumnDefinition } from '../../../interfaces/column-definition';
+
+/**
+ * Header cell control that opens an overlay for picking which values of a column stay visible in
+ * the table. Selecting nothing means the column does not filter at all.
+ */
+@Component({
+  selector: 'app-column-filter',
+  imports: [
+    A11yModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatSelectModule,
+    OverlayModule,
+  ],
+  templateUrl: './column-filter.html',
+  styleUrl: './column-filter.scss',
+})
+export class ColumnFilter {
+  readonly column = input.required<ColumnDefinition>();
+  readonly options = input.required<string[]>();
+  readonly selectedValues = model.required<string[]>();
+
+  readonly isOpen = signal(false);
+  readonly hasSelection = computed(() => this.selectedValues().length > 0);
+  readonly triggerLabel = computed(() => {
+    const displayName = this.column().displayName;
+    const selectedCount = this.selectedValues().length;
+
+    return selectedCount === 0
+      ? `Filter ${displayName} column`
+      : `Filter ${displayName} column, ${selectedCount} selected`;
+  });
+
+  toggle(): void {
+    this.isOpen.update((isOpen) => !isOpen);
+  }
+
+  close(): void {
+    this.isOpen.set(false);
+  }
+
+  clear(): void {
+    this.selectedValues.set([]);
+  }
+}

--- a/src/app/components/mat-table/column-select/column-select.spec.ts
+++ b/src/app/components/mat-table/column-select/column-select.spec.ts
@@ -9,16 +9,23 @@ describe('ColumnSelect', () => {
   let fixture: ComponentFixture<ColumnSelect>;
 
   const mockColumns: ColumnDefinition[] = [
-    { name: 'name', displayName: 'Name', isSortable: true, width: 150 },
-    { name: 'atomic_mass', displayName: 'Atomic Mass', isSortable: true, width: 150 },
-    { name: 'symbol', displayName: 'Symbol', isSortable: true, width: 150 },
-    { name: 'number', displayName: 'Number', isSortable: true, width: 150 },
+    { name: 'name', displayName: 'Name', isSortable: true, isFilterable: true, width: 150 },
+    {
+      name: 'atomic_mass',
+      displayName: 'Atomic Mass',
+      isSortable: true,
+      isFilterable: false,
+      width: 150,
+    },
+    { name: 'symbol', displayName: 'Symbol', isSortable: true, isFilterable: false, width: 150 },
+    { name: 'number', displayName: 'Number', isSortable: true, isFilterable: false, width: 150 },
   ];
   const [nameColumn, atomicMassColumn, symbolColumn, numberColumn] = mockColumns;
   const sourceColumn: ColumnDefinition = {
     name: 'source',
     displayName: 'Source',
     isSortable: false,
+    isFilterable: false,
     width: 150,
   };
 

--- a/src/app/components/mat-table/filter/filter.ts
+++ b/src/app/components/mat-table/filter/filter.ts
@@ -1,7 +1,7 @@
 import { Component, model } from '@angular/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { FilterState } from '../../../interfaces/filter-state';
+import { NameFilter } from '../../../interfaces/filter-state';
 
 @Component({
   selector: 'app-filter',
@@ -10,7 +10,7 @@ import { FilterState } from '../../../interfaces/filter-state';
   styleUrl: './filter.scss',
 })
 export class Filter {
-  readonly value = model<FilterState>({ name: '' });
+  readonly value = model<NameFilter>({ name: '' });
 
   setValue(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -39,7 +39,7 @@
     <!-- Columns Definitions -->
     @for (column of columnsToDisplay(); track column.name) {
       <ng-container matColumnDef="{{ column.name }}">
-        @if (column.isSortable) {
+        @if (column.isSortable && column.isFilterable) {
           <th
             mat-header-cell
             *matHeaderCellDef
@@ -49,6 +49,41 @@
             (widthChange)="setColumnWidth(column.name, $event)"
           >
             {{ column.displayName }}
+            <button
+              mat-icon-button
+              [attr.aria-label]="'Filter column ' + column.displayName"
+              type="button"
+            >
+              <mat-icon fontIcon="filter_alt" aria-hidden="true" />
+            </button>
+          </th>
+        } @else if (column.isSortable) {
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            mat-sort-header
+            [appColumnResize]="column.name"
+            [style.width.px]="column.width"
+            (widthChange)="setColumnWidth(column.name, $event)"
+          >
+            {{ column.displayName }}
+          </th>
+        } @else if (column.isFilterable) {
+          <th
+            mat-header-cell
+            *matHeaderCellDef
+            [appColumnResize]="column.name"
+            [style.width.px]="column.width"
+            (widthChange)="setColumnWidth(column.name, $event)"
+          >
+            {{ column.displayName }}
+            <button
+              mat-icon-button
+              [attr.aria-label]="'Filter column ' + column.displayName"
+              type="button"
+            >
+              <mat-icon fontIcon="filter_alt" aria-hidden="true" />
+            </button>
           </th>
         } @else {
           <th

--- a/src/app/components/mat-table/mat-table.html
+++ b/src/app/components/mat-table/mat-table.html
@@ -1,4 +1,4 @@
-<app-filter (valueChange)="applyFilter($event)" />
+<app-filter (valueChange)="applyNameFilter($event)" />
 <div class="column-chooser-container">
   Edit Columns:
   <button
@@ -39,51 +39,26 @@
     <!-- Columns Definitions -->
     @for (column of columnsToDisplay(); track column.name) {
       <ng-container matColumnDef="{{ column.name }}">
-        @if (column.isSortable && column.isFilterable) {
+        @if (column.isSortable) {
           <th
             mat-header-cell
             *matHeaderCellDef
             mat-sort-header
             [appColumnResize]="column.name"
             [style.width.px]="column.width"
+            [class.filterable-header]="column.isFilterable"
             (widthChange)="setColumnWidth(column.name, $event)"
           >
             {{ column.displayName }}
-            <button
-              mat-icon-button
-              [attr.aria-label]="'Filter column ' + column.displayName"
-              type="button"
-            >
-              <mat-icon fontIcon="filter_alt" aria-hidden="true" />
-            </button>
-          </th>
-        } @else if (column.isSortable) {
-          <th
-            mat-header-cell
-            *matHeaderCellDef
-            mat-sort-header
-            [appColumnResize]="column.name"
-            [style.width.px]="column.width"
-            (widthChange)="setColumnWidth(column.name, $event)"
-          >
-            {{ column.displayName }}
-          </th>
-        } @else if (column.isFilterable) {
-          <th
-            mat-header-cell
-            *matHeaderCellDef
-            [appColumnResize]="column.name"
-            [style.width.px]="column.width"
-            (widthChange)="setColumnWidth(column.name, $event)"
-          >
-            {{ column.displayName }}
-            <button
-              mat-icon-button
-              [attr.aria-label]="'Filter column ' + column.displayName"
-              type="button"
-            >
-              <mat-icon fontIcon="filter_alt" aria-hidden="true" />
-            </button>
+            @if (column.isFilterable) {
+              <app-column-filter
+                appHeaderCellAction
+                [column]="column"
+                [options]="columnFilterOptions(column.name)"
+                [selectedValues]="columnFilterValues(column.name)"
+                (selectedValuesChange)="setColumnFilter(column.name, $event)"
+              />
+            }
           </th>
         } @else {
           <th
@@ -91,9 +66,19 @@
             *matHeaderCellDef
             [appColumnResize]="column.name"
             [style.width.px]="column.width"
+            [class.filterable-header]="column.isFilterable"
             (widthChange)="setColumnWidth(column.name, $event)"
           >
             {{ column.displayName }}
+            @if (column.isFilterable) {
+              <app-column-filter
+                appHeaderCellAction
+                [column]="column"
+                [options]="columnFilterOptions(column.name)"
+                [selectedValues]="columnFilterValues(column.name)"
+                (selectedValuesChange)="setColumnFilter(column.name, $event)"
+              />
+            }
           </th>
         }
         @if (column.name === 'source' || column.name === 'bohr_model_3d') {

--- a/src/app/components/mat-table/mat-table.scss
+++ b/src/app/components/mat-table/mat-table.scss
@@ -25,6 +25,23 @@ table {
   position: relative;
 }
 
+// The trigger is hoisted into the `th` by HeaderCellAction, so it is pinned to the trailing edge
+// of the cell instead of flowing after the header label. The offset clears the resize handle.
+.resizable-table th.mat-mdc-header-cell app-column-filter {
+  position: absolute;
+  inset-inline-end: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
+// Sortable headers keep their label inside the sort container, which is capped in the global
+// stylesheet. A filterable header without sorting renders the label straight in the cell, so the
+// cell itself has to reserve the room the trigger occupies.
+.resizable-table th.filterable-header:not(.mat-sort-header) {
+  padding-inline-end: 44px;
+}
+
 .resizable-table .resize-spacer-cell {
   padding: 0;
   overflow: hidden;

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -411,6 +411,22 @@ describe('MatTable', () => {
       expect([...phases]).toEqual(['Gas']);
     });
 
+    it('ignores blank entries inside a column selection', () => {
+      component.dataSource.filter = JSON.stringify({
+        name: '',
+        columnValues: { phase: ['Gas', ''] },
+      });
+
+      const phases = new Set(component.dataSource.filteredData.map((element) => element.phase));
+      expect([...phases]).toEqual(['Gas']);
+    });
+
+    it('drops a column whose selection holds nothing but blank entries', () => {
+      component.dataSource.filter = JSON.stringify({ name: '', columnValues: { phase: ['', ''] } });
+
+      expect(component.dataSource.filteredData).toHaveLength(component.dataSource.data.length);
+    });
+
     it('falls back to an empty filter state when columnValues is not an object', () => {
       component.dataSource.filter = JSON.stringify({ name: '', columnValues: 'nope' });
 

--- a/src/app/components/mat-table/mat-table.spec.ts
+++ b/src/app/components/mat-table/mat-table.spec.ts
@@ -15,8 +15,9 @@ import {
   SPECTRAL_IMG_COLUMN,
   SYMBOL_COLUMN,
 } from '../../interfaces/columns';
-import { FilterState } from '../../interfaces/filter-state';
+import { FilterState, EMPTY_FILTER_STATE, NameFilter } from '../../interfaces/filter-state';
 import { LocalStorage } from '../../services/local-storage';
+import { ColumnFilter } from './column-filter/column-filter';
 import { ColumnSelect } from './column-select/column-select';
 import { MatTable } from './mat-table';
 
@@ -218,18 +219,18 @@ describe('MatTable', () => {
 
   describe('Filtering', () => {
     it('initializes dataSource filter to an empty serialized filter state', () => {
-      expect(component.dataSource.filter).toBe(JSON.stringify({ name: '' }));
+      expect(component.dataSource.filter).toBe(JSON.stringify(EMPTY_FILTER_STATE));
     });
 
     it('applies serialized filter state to dataSource', () => {
-      const filterState: FilterState = { name: 'helium' };
+      const filterState: FilterState = { name: 'helium', columnValues: {} };
       component.applyFilter(filterState);
       expect(component.dataSource.filter).toBe(JSON.stringify(filterState));
     });
 
     it('applies filter without pagination if paginator is absent', () => {
       component.dataSource.paginator = null;
-      const filterState: FilterState = { name: 'hydrogen' };
+      const filterState: FilterState = { name: 'hydrogen', columnValues: {} };
       component.applyFilter(filterState);
       expect(component.dataSource.filter).toBe(JSON.stringify(filterState));
     });
@@ -242,32 +243,44 @@ describe('MatTable', () => {
       }
       const firstPageSpy = vi.spyOn(paginator, 'firstPage');
 
-      component.applyFilter({ name: 'h' });
+      component.applyFilter({ name: 'h', columnValues: {} });
 
       expect(firstPageSpy).toHaveBeenCalledTimes(1);
     });
 
     it('handles empty filter string', () => {
-      component.applyFilter({ name: '' });
-      expect(component.dataSource.filter).toBe(JSON.stringify({ name: '' }));
+      component.applyFilter(EMPTY_FILTER_STATE);
+      expect(component.dataSource.filter).toBe(JSON.stringify(EMPTY_FILTER_STATE));
     });
 
     it('handles filter with special characters', () => {
-      component.applyFilter({ name: 'au*' });
-      expect(component.dataSource.filter).toBe(JSON.stringify({ name: 'au*' }));
+      component.applyFilter({ name: 'au*', columnValues: {} });
+      expect(component.dataSource.filter).toBe(
+        JSON.stringify({ name: 'au*', columnValues: {} } satisfies FilterState),
+      );
     });
 
     it('handles filter with numbers', () => {
-      component.applyFilter({ name: '79' });
-      expect(component.dataSource.filter).toBe(JSON.stringify({ name: '79' }));
+      component.applyFilter({ name: '79', columnValues: {} });
+      expect(component.dataSource.filter).toBe(
+        JSON.stringify({ name: '79', columnValues: {} } satisfies FilterState),
+      );
     });
 
     it('filters names using case-insensitive startsWith predicate', () => {
-      component.applyFilter({ name: 'heL' });
+      component.applyFilter({ name: 'heL', columnValues: {} });
       const filteredNames = component.dataSource.filteredData.map(({ name }) => name);
 
       expect(filteredNames.length).toBeGreaterThan(0);
       expect(filteredNames.every((name) => name.toLowerCase().startsWith('hel'))).toBeTruthy();
+    });
+
+    it('keeps the column filters when the search box reports a new name', () => {
+      component.setColumnFilter('phase', ['Gas']);
+
+      component.applyNameFilter({ name: 'he' });
+
+      expect(component.filterState()).toEqual({ name: 'he', columnValues: { phase: ['Gas'] } });
     });
 
     it('falls back to empty filter state when filter string is empty', () => {
@@ -285,7 +298,7 @@ describe('MatTable', () => {
     it('caches parsed filter state for repeated predicate evaluations with same filter', () => {
       const parseSpy = vi.spyOn(JSON, 'parse');
       const element = component.dataSource.data[0];
-      const filter = JSON.stringify({ name: 'he' });
+      const filter = JSON.stringify({ name: 'he', columnValues: {} } satisfies FilterState);
 
       component.dataSource.filterPredicate(element, filter);
       component.dataSource.filterPredicate(element, filter);
@@ -293,6 +306,115 @@ describe('MatTable', () => {
 
       expect(parseSpy).toHaveBeenCalledTimes(1);
       parseSpy.mockRestore();
+    });
+  });
+
+  describe('Column Value Filtering', () => {
+    it('offers every distinct value of a column in alphabetical order', () => {
+      const options = component.columnFilterOptions('phase');
+
+      expect(options).toEqual([...new Set(options)]);
+      expect(options).toEqual([...options].sort((a, b) => a.localeCompare(b)));
+      expect(options).toContain('Gas');
+      expect(options).toContain('Solid');
+    });
+
+    it('reuses the same option array for repeated reads of a column', () => {
+      expect(component.columnFilterOptions('phase')).toBe(component.columnFilterOptions('phase'));
+    });
+
+    it('leaves out blank values from the offered options', () => {
+      expect(component.columnFilterOptions('appearance')).not.toContain('');
+    });
+
+    it('reports no selected values for a column that is not filtered', () => {
+      expect(component.columnFilterValues('phase')).toEqual([]);
+    });
+
+    it('reuses the same empty array for every unfiltered column', () => {
+      expect(component.columnFilterValues('phase')).toBe(component.columnFilterValues('category'));
+    });
+
+    it('keeps only the rows matching the selected values of a column', () => {
+      component.setColumnFilter('phase', ['Gas']);
+
+      const phases = new Set(component.dataSource.filteredData.map((element) => element.phase));
+      expect(component.dataSource.filteredData.length).toBeGreaterThan(0);
+      expect([...phases]).toEqual(['Gas']);
+    });
+
+    it('keeps the rows matching any of the selected values of a column', () => {
+      component.setColumnFilter('phase', ['Gas', 'Liquid']);
+
+      const phases = new Set(component.dataSource.filteredData.map((element) => element.phase));
+      expect([...phases].sort()).toEqual(['Gas', 'Liquid']);
+    });
+
+    it('combines filters on different columns', () => {
+      component.setColumnFilter('phase', ['Solid']);
+      component.setColumnFilter('block', ['s']);
+
+      expect(component.dataSource.filteredData.length).toBeGreaterThan(0);
+      expect(
+        component.dataSource.filteredData.every(
+          (element) => element.phase === 'Solid' && element.block === 's',
+        ),
+      ).toBeTruthy();
+    });
+
+    it('combines a column filter with the free text search', () => {
+      component.applyNameFilter({ name: 'he' });
+      component.setColumnFilter('phase', ['Gas']);
+
+      expect(
+        component.dataSource.filteredData.every(
+          (element) => element.name.toLowerCase().startsWith('he') && element.phase === 'Gas',
+        ),
+      ).toBeTruthy();
+    });
+
+    it('drops the column from the filter state when the selection is emptied', () => {
+      component.setColumnFilter('phase', ['Gas']);
+      expect(component.filterState().columnValues).toEqual({ phase: ['Gas'] });
+
+      component.setColumnFilter('phase', []);
+
+      expect(component.filterState().columnValues).toEqual({});
+      expect(component.dataSource.filteredData).toHaveLength(component.dataSource.data.length);
+    });
+
+    it('resets to the first page when a column filter changes', () => {
+      const paginator = component.paginator();
+      if (!paginator) {
+        throw new Error('Expected paginator to be available');
+      }
+      const firstPageSpy = vi.spyOn(paginator, 'firstPage');
+
+      component.setColumnFilter('phase', ['Gas']);
+
+      expect(firstPageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores column selections that are not string arrays when parsing the filter', () => {
+      component.dataSource.filter = JSON.stringify({ name: '', columnValues: { phase: 'Gas' } });
+
+      expect(component.dataSource.filteredData).toHaveLength(component.dataSource.data.length);
+    });
+
+    it('ignores non-string entries inside a column selection', () => {
+      component.dataSource.filter = JSON.stringify({
+        name: '',
+        columnValues: { phase: ['Gas', 7, null] },
+      });
+
+      const phases = new Set(component.dataSource.filteredData.map((element) => element.phase));
+      expect([...phases]).toEqual(['Gas']);
+    });
+
+    it('falls back to an empty filter state when columnValues is not an object', () => {
+      component.dataSource.filter = JSON.stringify({ name: '', columnValues: 'nope' });
+
+      expect(component.dataSource.filteredData).toHaveLength(component.dataSource.data.length);
     });
   });
 
@@ -462,6 +584,81 @@ describe('MatTable', () => {
       fixture.detectChanges();
 
       expect(component.columnsToDisplay()).toEqual(newColumns);
+    });
+  });
+
+  describe('Template Integration - Column Filter', () => {
+    function columnFilterFor(column: string) {
+      return fixture.debugElement
+        .queryAll(By.directive(ColumnFilter))
+        .find((filter) => (filter.componentInstance as ColumnFilter).column().name === column);
+    }
+
+    it('renders a filter control only in headers of filterable columns', () => {
+      const filteredColumns = fixture.debugElement
+        .queryAll(By.directive(ColumnFilter))
+        .map((filter) => (filter.componentInstance as ColumnFilter).column().name);
+
+      expect(filteredColumns).toEqual(
+        DEFAULT_COLUMNS.filter((column) => column.isFilterable).map((column) => column.name),
+      );
+    });
+
+    it('marks filterable headers so their layout reserves room for the control', () => {
+      const filterableHeader = fixture.debugElement.query(By.css('th.mat-column-phase'));
+      const plainHeader = fixture.debugElement.query(By.css('th.mat-column-symbol'));
+
+      expect((filterableHeader.nativeElement as HTMLElement).classList).toContain(
+        'filterable-header',
+      );
+      expect((plainHeader.nativeElement as HTMLElement).classList).not.toContain(
+        'filterable-header',
+      );
+    });
+
+    it('places the control in the header cell rather than inside the sort button', () => {
+      const phaseFilter = columnFilterFor('phase');
+      expect(phaseFilter).toBeTruthy();
+
+      const element = phaseFilter?.nativeElement as HTMLElement;
+      expect(element.parentElement?.tagName).toBe('TH');
+      expect(element.closest('[role="button"]')).toBeNull();
+    });
+
+    it('passes the distinct column values to the control', () => {
+      const phaseFilter = columnFilterFor('phase');
+      const options = (phaseFilter?.componentInstance as ColumnFilter).options();
+
+      expect(options).toEqual(component.columnFilterOptions('phase'));
+      expect(options).toContain('Gas');
+    });
+
+    it('filters the table when the control emits a new selection', () => {
+      const phaseFilter = columnFilterFor('phase');
+
+      phaseFilter?.triggerEventHandler('selectedValuesChange', ['Gas']);
+      fixture.detectChanges();
+
+      expect(component.filterState().columnValues).toEqual({ phase: ['Gas'] });
+      expect(
+        component.dataSource.filteredData.every((element) => element.phase === 'Gas'),
+      ).toBeTruthy();
+    });
+
+    it('feeds the current selection back into the control', () => {
+      component.setColumnFilter('phase', ['Liquid']);
+      fixture.detectChanges();
+
+      expect(
+        (columnFilterFor('phase')?.componentInstance as ColumnFilter).selectedValues(),
+      ).toEqual(['Liquid']);
+    });
+
+    it('drops the control when its column stops being displayed', () => {
+      component.setColumnsToDisplay([SYMBOL_COLUMN]);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.queryAll(By.directive(ColumnFilter))).toHaveLength(0);
     });
   });
 
@@ -677,13 +874,13 @@ describe('MatTable', () => {
       expect(filter).toBeTruthy();
     });
 
-    it('calls applyFilter when app-filter emits valueChange', () => {
+    it('calls applyNameFilter when app-filter emits valueChange', () => {
       const filter = fixture.debugElement.query(By.css('app-filter'));
-      const spy = vi.spyOn(component, 'applyFilter');
-      const filterState: FilterState = { name: 'test' };
+      const spy = vi.spyOn(component, 'applyNameFilter');
+      const nameFilter: NameFilter = { name: 'test' };
 
-      filter.triggerEventHandler('valueChange', filterState);
-      expect(spy).toHaveBeenCalledWith(filterState);
+      filter.triggerEventHandler('valueChange', nameFilter);
+      expect(spy).toHaveBeenCalledWith(nameFilter);
     });
   });
 
@@ -784,7 +981,7 @@ describe('MatTable', () => {
 
     it('handles filtering with special characters in search', () => {
       expect(() => {
-        component.applyFilter({ name: '!@#$%' });
+        component.applyFilter({ name: '!@#$%', columnValues: {} });
       }).not.toThrow();
     });
 

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -260,8 +260,10 @@ export class MatTable {
 
     for (const [column, values] of Object.entries(value)) {
       if (Array.isArray(values)) {
+        // Blank values are never offered as filter options, so accepting them here would build a
+        // filter state the UI cannot reproduce and that hides every row with a populated cell.
         const stringValues = (values as unknown[]).filter(
-          (entry): entry is string => typeof entry === 'string',
+          (entry): entry is string => typeof entry === 'string' && entry !== '',
         );
 
         if (stringValues.length > 0) {

--- a/src/app/components/mat-table/mat-table.ts
+++ b/src/app/components/mat-table/mat-table.ts
@@ -7,22 +7,40 @@ import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { ColumnResize } from '../../directives/column-resize';
+import { HeaderCellAction } from '../../directives/header-cell-action';
 import { ColumnDefinition } from '../../interfaces/column-definition';
 import { EXPAND_COLUMN_WIDTH, RESIZE_SPACER_COLUMN } from '../../interfaces/columns';
 import { ELEMENT_DATA } from '../../interfaces/data';
-import { FilterState } from '../../interfaces/filter-state';
+import { EMPTY_FILTER_STATE, FilterState, NameFilter } from '../../interfaces/filter-state';
 import { PeriodicElement } from '../../interfaces/periodic-element';
 import { AppState } from '../../services/app-state';
+import { ColumnFilter } from './column-filter/column-filter';
 import { ColumnSelect } from './column-select/column-select';
 import { Filter } from './filter/filter';
 import { PeriodicElementDetail } from './periodic-element-detail/periodic-element-detail';
 
+/**
+ * Reads a column off an element as the string the header filters compare against. Columns holding
+ * anything but a primitive (images, lists) have no meaningful filter value, so they read as blank.
+ */
+function readColumnValue(element: PeriodicElement, column: string): string {
+  const value = (element as unknown as Record<string, unknown>)[column];
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return typeof value === 'number' || typeof value === 'boolean' ? String(value) : '';
+}
+
 @Component({
   selector: 'app-mat-table',
   imports: [
+    ColumnFilter,
     ColumnResize,
     ColumnSelect,
     Filter,
+    HeaderCellAction,
     MatButtonModule,
     MatIconModule,
     MatPaginatorModule,
@@ -37,9 +55,13 @@ import { PeriodicElementDetail } from './periodic-element-detail/periodic-elemen
 })
 export class MatTable {
   private readonly appState = inject(AppState);
-  private readonly emptyFilterState: FilterState = { name: '' };
-  private cachedFilterString = JSON.stringify(this.emptyFilterState);
-  private cachedFilterState = this.emptyFilterState;
+  private cachedFilterString = JSON.stringify(EMPTY_FILTER_STATE);
+  private cachedFilterState = EMPTY_FILTER_STATE;
+  // The option list of a column never changes, so it is derived once and then reused. Returning the
+  // same array on every read also keeps the `app-column-filter` input from churning.
+  private readonly filterOptionsCache = new Map<string, string[]>();
+  // Shared empty selection, so an unfiltered column always reads back the same array reference.
+  private readonly noSelectedValues: string[] = [];
 
   readonly paginator = viewChild(MatPaginator);
   readonly sort = viewChild(MatSort);
@@ -66,14 +88,21 @@ export class MatTable {
   readonly expandedElement = signal<PeriodicElement | null>(null);
   readonly isOpen = signal(false);
   readonly expandColumnWidth = EXPAND_COLUMN_WIDTH;
+  readonly filterState = signal<FilterState>(EMPTY_FILTER_STATE);
 
   constructor() {
     this.dataSource.filterPredicate = (data: PeriodicElement, filter: string) => {
       const filterState = this.getCachedFilterState(filter);
 
-      return data.name.toLowerCase().startsWith(filterState.name.toLowerCase());
+      if (!data.name.toLowerCase().startsWith(filterState.name.toLowerCase())) {
+        return false;
+      }
+
+      return Object.entries(filterState.columnValues).every(
+        ([column, values]) => values.length === 0 || values.includes(readColumnValue(data, column)),
+      );
     };
-    this.dataSource.filter = JSON.stringify(this.emptyFilterState);
+    this.dataSource.filter = JSON.stringify(EMPTY_FILTER_STATE);
     effect(() => {
       const paginator = this.paginator();
       const sort = this.sort();
@@ -88,11 +117,59 @@ export class MatTable {
   }
 
   applyFilter(event: FilterState) {
+    this.filterState.set(event);
     this.dataSource.filter = JSON.stringify(event);
 
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }
+  }
+
+  /** Merges the free text search box value into the filter state, keeping the column filters. */
+  applyNameFilter(event: NameFilter) {
+    this.applyFilter({ ...this.filterState(), name: event.name });
+  }
+
+  /** Replaces the values selected for a single column; an empty selection drops the filter. */
+  setColumnFilter(column: string, values: string[]) {
+    const currentState = this.filterState();
+    const columnValues = { ...currentState.columnValues };
+
+    if (values.length === 0) {
+      delete columnValues[column];
+    } else {
+      columnValues[column] = values;
+    }
+
+    this.applyFilter({ ...currentState, columnValues });
+  }
+
+  columnFilterValues(column: string): string[] {
+    return this.filterState().columnValues[column] ?? this.noSelectedValues;
+  }
+
+  /** Every distinct value a column holds, in alphabetical order, offered as filter options. */
+  columnFilterOptions(column: string): string[] {
+    const cachedOptions = this.filterOptionsCache.get(column);
+
+    if (cachedOptions) {
+      return cachedOptions;
+    }
+
+    const values = new Set<string>();
+
+    for (const element of this.dataSource.data) {
+      const value = readColumnValue(element, column);
+
+      if (value !== '') {
+        values.add(value);
+      }
+    }
+
+    const options = [...values].sort((a, b) => a.localeCompare(b));
+    this.filterOptionsCache.set(column, options);
+
+    return options;
   }
 
   toggleExpanded(event: Event, element: PeriodicElement) {
@@ -147,19 +224,23 @@ export class MatTable {
 
   private parseFilterState(filter: string): FilterState {
     if (!filter) {
-      return this.emptyFilterState;
+      return EMPTY_FILTER_STATE;
     }
 
     try {
       const parsedFilter = JSON.parse(filter) as unknown;
 
-      if (
-        typeof parsedFilter === 'object' &&
-        parsedFilter !== null &&
-        'name' in parsedFilter &&
-        typeof parsedFilter.name === 'string'
-      ) {
-        return { name: parsedFilter.name };
+      if (typeof parsedFilter === 'object' && parsedFilter !== null && 'name' in parsedFilter) {
+        const { name } = parsedFilter;
+
+        if (typeof name === 'string') {
+          return {
+            name,
+            columnValues: this.parseColumnValues(
+              'columnValues' in parsedFilter ? parsedFilter.columnValues : undefined,
+            ),
+          };
+        }
       }
     } catch (error) {
       if (!(error instanceof SyntaxError)) {
@@ -167,6 +248,28 @@ export class MatTable {
       }
     }
 
-    return this.emptyFilterState;
+    return EMPTY_FILTER_STATE;
+  }
+
+  private parseColumnValues(value: unknown): Record<string, string[]> {
+    if (typeof value !== 'object' || value === null) {
+      return {};
+    }
+
+    const columnValues: Record<string, string[]> = {};
+
+    for (const [column, values] of Object.entries(value)) {
+      if (Array.isArray(values)) {
+        const stringValues = (values as unknown[]).filter(
+          (entry): entry is string => typeof entry === 'string',
+        );
+
+        if (stringValues.length > 0) {
+          columnValues[column] = stringValues;
+        }
+      }
+    }
+
+    return columnValues;
   }
 }

--- a/src/app/directives/header-cell-action.spec.ts
+++ b/src/app/directives/header-cell-action.spec.ts
@@ -1,0 +1,112 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { vi } from 'vitest';
+import { HeaderCellAction } from './header-cell-action';
+
+@Component({
+  selector: 'app-host',
+  imports: [HeaderCellAction],
+  template: `<table>
+    <thead>
+      <tr>
+        <th (click)="onCellEvent()" (keydown)="onCellEvent()">
+          <div class="sort-container">
+            Header
+            <button appHeaderCellAction type="button" (click)="onActionClick()">Action</button>
+          </div>
+        </th>
+      </tr>
+    </thead>
+  </table>`,
+})
+class HostComponent {
+  cellEvents = 0;
+  actionClicks = 0;
+
+  onCellEvent(): void {
+    this.cellEvents += 1;
+  }
+
+  onActionClick(): void {
+    this.actionClicks += 1;
+  }
+}
+
+@Component({
+  selector: 'app-detached-host',
+  imports: [HeaderCellAction],
+  template: `<div class="sort-container">
+    <button appHeaderCellAction type="button">Action</button>
+  </div>`,
+})
+class DetachedHostComponent {}
+
+describe('HeaderCellAction', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+  let headerCell: HTMLElement;
+  let action: HTMLButtonElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent, DetachedHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    headerCell = fixture.debugElement.query(By.css('th')).nativeElement as HTMLElement;
+    action = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
+  });
+
+  it('moves the control out of the sort container and into the header cell', () => {
+    expect(action.parentElement).toBe(headerCell);
+    expect(headerCell.querySelector('.sort-container')?.contains(action)).toBeFalsy();
+  });
+
+  it('keeps the control bound to its component after being moved', () => {
+    action.click();
+
+    expect(host.actionClicks).toBe(1);
+  });
+
+  it('stops clicks from reaching the sort header on the cell', () => {
+    action.click();
+
+    expect(host.cellEvents).toBe(0);
+  });
+
+  it('stops keyboard events from reaching the sort header on the cell', () => {
+    action.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(host.cellEvents).toBe(0);
+  });
+
+  it('leaves the cell reachable for events that do not come from the control', () => {
+    headerCell.click();
+
+    expect(host.cellEvents).toBe(1);
+  });
+
+  it('leaves the control where it is when there is no header cell to move it to', () => {
+    const detachedFixture = TestBed.createComponent(DetachedHostComponent);
+    detachedFixture.detectChanges();
+
+    const detachedAction = detachedFixture.debugElement.query(By.css('button'))
+      .nativeElement as HTMLElement;
+
+    expect(detachedAction.parentElement?.classList).toContain('sort-container');
+  });
+
+  it('does not move a control that already sits in the header cell', () => {
+    const alreadyPlaced = fixture.debugElement.query(By.directive(HeaderCellAction));
+    const appendSpy = vi.spyOn(headerCell, 'appendChild');
+
+    alreadyPlaced.injector.get(HeaderCellAction).ngAfterViewInit();
+
+    expect(appendSpy).not.toHaveBeenCalled();
+    expect(action.parentElement).toBe(headerCell);
+  });
+});

--- a/src/app/directives/header-cell-action.ts
+++ b/src/app/directives/header-cell-action.ts
@@ -1,0 +1,41 @@
+import { AfterViewInit, Directive, ElementRef, Renderer2, inject } from '@angular/core';
+
+/**
+ * Places an interactive control directly inside its header cell (`th`) and keeps its interactions
+ * from reaching the surrounding `mat-sort-header`.
+ *
+ * `MatSortHeader` projects everything inside the header cell into a `div[role="button"]`. A control
+ * declared in the header template therefore ends up as a focusable descendant of a button, which is
+ * an accessibility violation (nested interactive controls). Re-parenting the control to the header
+ * cell makes it a sibling of the sort container instead, so the header keeps `aria-sort` on the
+ * `th`, the sort button keeps its own semantics, and the control stays reachable on its own.
+ *
+ * The element node is only moved, never re-created, so Angular's bindings, outputs and view cleanup
+ * keep working: Angular resolves the parent node at removal time.
+ */
+@Directive({
+  selector: '[appHeaderCellAction]',
+  host: {
+    // The cell is the `mat-sort-header` host, which sorts on click and on Enter/Space, so events
+    // coming from this control must stop before they get there.
+    '(click)': 'stopEvent($event)',
+    '(keydown)': 'stopEvent($event)',
+  },
+})
+export class HeaderCellAction implements AfterViewInit {
+  private readonly element = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly renderer = inject(Renderer2);
+
+  ngAfterViewInit(): void {
+    const host = this.element.nativeElement;
+    const headerCell = host.closest('th');
+
+    if (headerCell && host.parentElement !== headerCell) {
+      this.renderer.appendChild(headerCell, host);
+    }
+  }
+
+  stopEvent(event: Event): void {
+    event.stopPropagation();
+  }
+}

--- a/src/app/interfaces/column-definition.ts
+++ b/src/app/interfaces/column-definition.ts
@@ -2,5 +2,6 @@ export interface ColumnDefinition {
   name: string;
   displayName: string;
   isSortable: boolean;
+  isFilterable: boolean;
   width: number;
 }

--- a/src/app/interfaces/columns.ts
+++ b/src/app/interfaces/columns.ts
@@ -43,7 +43,7 @@ export const CATEGORY_COLUMN: ColumnDefinition = {
   name: 'category',
   displayName: 'Category',
   isSortable: true,
-  isFilterable: false,
+  isFilterable: true,
   width: 200,
 };
 
@@ -115,7 +115,7 @@ export const PHASE_COLUMN: ColumnDefinition = {
   name: 'phase',
   displayName: 'Phase',
   isSortable: true,
-  isFilterable: false,
+  isFilterable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -251,7 +251,7 @@ export const BLOCK_COLUMN: ColumnDefinition = {
   name: 'block',
   displayName: 'Block',
   isSortable: true,
-  isFilterable: false,
+  isFilterable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 

--- a/src/app/interfaces/columns.ts
+++ b/src/app/interfaces/columns.ts
@@ -11,6 +11,7 @@ export const NAME_COLUMN: ColumnDefinition = {
   name: 'name',
   displayName: 'Name',
   isSortable: true,
+  isFilterable: true,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -18,6 +19,7 @@ export const APPEARANCE_COLUMN: ColumnDefinition = {
   name: 'appearance',
   displayName: 'Appearance',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -25,6 +27,7 @@ export const ATOMIC_MASS_COLUMN: ColumnDefinition = {
   name: 'atomic_mass',
   displayName: 'Atomic Mass',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -32,6 +35,7 @@ export const BOIL_COLUMN: ColumnDefinition = {
   name: 'boil',
   displayName: 'Boiling Point',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -39,6 +43,7 @@ export const CATEGORY_COLUMN: ColumnDefinition = {
   name: 'category',
   displayName: 'Category',
   isSortable: true,
+  isFilterable: false,
   width: 200,
 };
 
@@ -46,6 +51,7 @@ export const DENSITY_COLUMN: ColumnDefinition = {
   name: 'density',
   displayName: 'Density',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -53,6 +59,7 @@ export const DISCOVERED_BY_COLUMN: ColumnDefinition = {
   name: 'discovered_by',
   displayName: 'Discovered By',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -60,6 +67,7 @@ export const MELT_COLUMN: ColumnDefinition = {
   name: 'melt',
   displayName: 'Melting Point',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -67,6 +75,7 @@ export const MOLAR_HEAT_COLUMN: ColumnDefinition = {
   name: 'molar_heat',
   displayName: 'Molar Heat',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -74,6 +83,7 @@ export const NAMED_BY_COLUMN: ColumnDefinition = {
   name: 'named_by',
   displayName: 'Named By',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -81,6 +91,7 @@ export const NUMBER_COLUMN: ColumnDefinition = {
   name: 'number',
   displayName: 'Number',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -88,6 +99,7 @@ export const PERIOD_COLUMN: ColumnDefinition = {
   name: 'period',
   displayName: 'Period',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -95,6 +107,7 @@ export const GROUP_COLUMN: ColumnDefinition = {
   name: 'group',
   displayName: 'Group',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -102,6 +115,7 @@ export const PHASE_COLUMN: ColumnDefinition = {
   name: 'phase',
   displayName: 'Phase',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -109,6 +123,7 @@ export const BOHR_MODEL_IMAGE_COLUMN: ColumnDefinition = {
   name: 'bohr_model_image',
   displayName: 'Bohr Model Image',
   isSortable: false,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -116,6 +131,7 @@ export const BOHR_MODEL_3D_COLUMN: ColumnDefinition = {
   name: 'bohr_model_3d',
   displayName: 'Bohr Model 3D',
   isSortable: false,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -123,6 +139,7 @@ export const SPECTRAL_IMG_COLUMN: ColumnDefinition = {
   name: 'spectral_img',
   displayName: 'Spectral Image',
   isSortable: false,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -130,6 +147,7 @@ export const SUMMARY_COLUMN: ColumnDefinition = {
   name: 'summary',
   displayName: 'Summary',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -137,6 +155,7 @@ export const SYMBOL_COLUMN: ColumnDefinition = {
   name: 'symbol',
   displayName: 'Symbol',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -144,6 +163,7 @@ export const XPOS_COLUMN: ColumnDefinition = {
   name: 'xpos',
   displayName: 'X Position',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -151,6 +171,7 @@ export const YPOS_COLUMN: ColumnDefinition = {
   name: 'ypos',
   displayName: 'Y Position',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -158,6 +179,7 @@ export const WXPOS_COLUMN: ColumnDefinition = {
   name: 'wxpos',
   displayName: 'Wide X Position',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -165,6 +187,7 @@ export const WYPOS_COLUMN: ColumnDefinition = {
   name: 'wypos',
   displayName: 'Wide Y Position',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -172,6 +195,7 @@ export const SHELLS_COLUMN: ColumnDefinition = {
   name: 'shells',
   displayName: 'Shells',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -179,6 +203,7 @@ export const ELECTRON_CONFIGURATION_COLUMN: ColumnDefinition = {
   name: 'electron_configuration',
   displayName: 'Electron Configuration',
   isSortable: true,
+  isFilterable: false,
   width: 200,
 };
 
@@ -186,6 +211,7 @@ export const ELECTRON_CONFIGURATION_SEMANTIC_COLUMN: ColumnDefinition = {
   name: 'electron_configuration_semantic',
   displayName: 'Electron Configuration (Semantic)',
   isSortable: true,
+  isFilterable: false,
   width: 300,
 };
 
@@ -193,6 +219,7 @@ export const ELECTRON_AFFINITY_COLUMN: ColumnDefinition = {
   name: 'electron_affinity',
   displayName: 'Electron Affinity',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -200,6 +227,7 @@ export const ELECTRONEGATIVITY_PAULING_COLUMN: ColumnDefinition = {
   name: 'electronegativity_pauling',
   displayName: 'Electronegativity (Pauling)',
   isSortable: true,
+  isFilterable: false,
   width: 250,
 };
 
@@ -207,6 +235,7 @@ export const IONIZATION_ENERGIES_COLUMN: ColumnDefinition = {
   name: 'ionization_energies',
   displayName: 'Ionization Energies',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -214,6 +243,7 @@ export const IMAGE_COLUMN: ColumnDefinition = {
   name: 'image',
   displayName: 'Image',
   isSortable: false,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -221,6 +251,7 @@ export const BLOCK_COLUMN: ColumnDefinition = {
   name: 'block',
   displayName: 'Block',
   isSortable: true,
+  isFilterable: false,
   width: DEFAULT_COLUMN_WIDTH,
 };
 
@@ -230,6 +261,7 @@ export const SOURCE_COLUMN: ColumnDefinition = {
   name: 'source',
   displayName: 'Source',
   isSortable: false,
+  isFilterable: false,
   width: 300,
 };
 

--- a/src/app/interfaces/filter-state.ts
+++ b/src/app/interfaces/filter-state.ts
@@ -1,3 +1,17 @@
-export interface FilterState {
+/** Value produced by the free text search box that sits above the table. */
+export interface NameFilter {
   name: string;
 }
+
+/**
+ * Everything the table filters on, serialized into `MatTableDataSource.filter`.
+ *
+ * `columnValues` maps a column name to the values picked in that column's header filter. A column
+ * is only present while it has at least one selected value, so an empty record means "no column
+ * filters are active".
+ */
+export interface FilterState extends NameFilter {
+  columnValues: Record<string, string[]>;
+}
+
+export const EMPTY_FILTER_STATE: FilterState = { name: '', columnValues: {} };

--- a/src/app/services/app-state.spec.ts
+++ b/src/app/services/app-state.spec.ts
@@ -119,6 +119,7 @@ describe('AppState', () => {
         name: 'unknown',
         displayName: 'Unknown',
         isSortable: false,
+        isFilterable: false,
         width: 100,
       };
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -143,3 +143,17 @@ body {
   transform: none;
   opacity: 0.54;
 }
+
+// Filterable headers keep a filter trigger pinned to the trailing edge of the cell (see
+// HeaderCellAction). Cap the sort container so a long header label ellipsizes before it
+// reaches the trigger instead of running underneath it. MatSortHeader renders the container
+// inside its own view, so this override cannot live in an encapsulated component style.
+th.filterable-header .mat-sort-header-container {
+  max-width: calc(100% - 44px);
+}
+
+th.filterable-header .mat-sort-header-content {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}

--- a/tests/mat-table.spec.ts
+++ b/tests/mat-table.spec.ts
@@ -292,4 +292,22 @@ test.describe('Mat table tab', () => {
     await expect(phaseHeader).toHaveAttribute('aria-sort', 'ascending');
     await expect(getColumnFilterTrigger(page, 'phase')).toBeVisible();
   });
+
+  test('exposes the column filter as a labelled modal dialog', async ({ page }) => {
+    const trigger = getColumnFilterTrigger(page, 'phase');
+    await expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await trigger.click();
+
+    const dialog = page.getByRole('dialog', { name: 'Filter Phase column' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // `aria-modal` marks everything outside the dialog inert for assistive tech, so the select
+    // options have to stay within the dialog subtree to remain reachable.
+    await page.locator('.column-filter-card mat-select').click();
+    await expect(dialog.getByRole('option')).toHaveText(['Gas', 'Liquid', 'Solid']);
+  });
 });

--- a/tests/mat-table.spec.ts
+++ b/tests/mat-table.spec.ts
@@ -18,6 +18,28 @@ function getExpandButton(page: Page, index: number) {
   );
 }
 
+function getColumnFilterTrigger(page: Page, column: string) {
+  return page.locator(`th.mat-column-${column} [data-testid="column-filter-trigger-${column}"]`);
+}
+
+/** Ticks an option in the open column filter's multiple select. */
+async function selectFilterOption(page: Page, option: string) {
+  const select = page.locator('.column-filter-card mat-select');
+
+  if ((await select.getAttribute('aria-expanded')) !== 'true') {
+    await select.click();
+  }
+
+  await page.getByRole('option', { name: option, exact: true }).click();
+}
+
+/** Escape closes the select panel first, so the overlay needs a second press to go away. */
+async function closeOverlays(page: Page) {
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Escape');
+  await expect(page.locator('.column-filter-card')).not.toBeAttached();
+}
+
 test.describe('Mat table tab', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
@@ -174,5 +196,100 @@ test.describe('Mat table tab', () => {
     await page.reload();
 
     await expect(page.locator('th.mat-column-name')).toHaveCSS('width', '166px');
+  });
+
+  test('shows a filter trigger only on filterable headers', async ({ page }) => {
+    await expect(getColumnFilterTrigger(page, 'phase')).toBeVisible();
+    await expect(getColumnFilterTrigger(page, 'category')).toBeVisible();
+    await expect(getColumnFilterTrigger(page, 'symbol')).not.toBeAttached();
+  });
+
+  test('keeps only the rows holding the values picked in a column filter', async ({ page }) => {
+    await getColumnFilterTrigger(page, 'phase').click();
+    await selectFilterOption(page, 'Gas');
+    await selectFilterOption(page, 'Liquid');
+    await closeOverlays(page);
+
+    const phases = await getDataRows(page).locator('td.mat-column-phase').allTextContents();
+    expect(phases.length).toBeGreaterThan(0);
+    expect([...new Set(phases.map((phase) => phase.trim()))].sort()).toEqual(['Gas', 'Liquid']);
+  });
+
+  test('narrows the rows further when a second column is filtered', async ({ page }) => {
+    await getColumnFilterTrigger(page, 'phase').click();
+    await selectFilterOption(page, 'Solid');
+    await closeOverlays(page);
+    const solidCount = await getDataRows(page).count();
+
+    await getColumnFilterTrigger(page, 'category').click();
+    await selectFilterOption(page, 'alkali metal');
+    await closeOverlays(page);
+
+    await expect(getDataRows(page)).not.toHaveCount(solidCount);
+    const categories = await getDataRows(page).locator('td.mat-column-category').allTextContents();
+    expect(categories.length).toBeGreaterThan(0);
+    expect(categories.every((category) => category.trim() === 'alkali metal')).toBeTruthy();
+  });
+
+  test('combines a column filter with the name search', async ({ page }) => {
+    await getColumnFilterTrigger(page, 'phase').click();
+    await selectFilterOption(page, 'Gas');
+    await closeOverlays(page);
+
+    await page.locator('input[matinput]').fill('he');
+
+    await expect(getDataRows(page)).toHaveCount(1);
+    await expect(getFirstRowNameCell(page)).toContainText('Helium');
+  });
+
+  test('restores every row when the column filter is cleared', async ({ page }) => {
+    await getColumnFilterTrigger(page, 'phase').click();
+    await selectFilterOption(page, 'Liquid');
+    await closeOverlays(page);
+    await expect(page.locator('.mat-mdc-paginator-range-label')).not.toContainText('of 119');
+
+    await getColumnFilterTrigger(page, 'phase').click();
+    await page.getByRole('button', { name: 'Clear filter' }).click();
+
+    await expect(page.locator('.mat-mdc-paginator-range-label')).toContainText('of 119');
+  });
+
+  test('resets the paginator to the first page when a column filter is applied', async ({
+    page,
+  }) => {
+    await page.locator('.mat-mdc-paginator-navigation-next').click();
+    await expect(page.locator('.mat-mdc-paginator-range-label')).toContainText('26 – 50');
+
+    await getColumnFilterTrigger(page, 'phase').click();
+    await selectFilterOption(page, 'Solid');
+    await closeOverlays(page);
+
+    await expect(page.locator('.mat-mdc-paginator-range-label')).toContainText('1 – 25');
+  });
+
+  test('opens the column filter from the keyboard without sorting the column', async ({ page }) => {
+    const phaseHeader = page.locator('th.mat-column-phase');
+    await expect(phaseHeader).toHaveAttribute('aria-sort', 'none');
+
+    await getColumnFilterTrigger(page, 'phase').focus();
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('.column-filter-card')).toBeVisible();
+    await expect(phaseHeader).toHaveAttribute('aria-sort', 'none');
+
+    // Focus is captured by the overlay and handed back to the trigger once it closes.
+    await expect(page.locator('.column-filter-card')).toContainText('Phase');
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.column-filter-card')).not.toBeAttached();
+    await expect(getColumnFilterTrigger(page, 'phase')).toBeFocused();
+  });
+
+  test('keeps the header sortable next to its filter trigger', async ({ page }) => {
+    const phaseHeader = page.locator('th.mat-column-phase');
+
+    await phaseHeader.locator('.mat-sort-header-container').click();
+
+    await expect(phaseHeader).toHaveAttribute('aria-sort', 'ascending');
+    await expect(getColumnFilterTrigger(page, 'phase')).toBeVisible();
   });
 });


### PR DESCRIPTION
# Pull Request

## Summary

Introduces a new `ColumnFilter` header control that opens a multi-select overlay for filterable columns, wires it into `MatTable`, and extends filter state to combine name search with per-column selected values. Adds `HeaderCellAction` to keep header actions out of the sort button for accessibility and preserve sortable headers. Updates filterable column definitions, styles/layout for header triggers, and expands unit + Playwright coverage for filtering behavior, keyboard interaction, pagination reset, and clear-state handling.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that alters existing behavior)
- [ ] Refactor or cleanup (no behavior change)
- [x] Tests (unit, scripts, or Playwright e2e)
- [ ] Build, CI, or tooling
- [ ] Dependency update
- [ ] Documentation or AI instructions

## Areas Touched

- [x] Angular app (`src/`)
- [x] End-to-end tests (`tests/`)
- [ ] Node scripts (`scripts/`)
- [ ] CI or workflows (`.github/`)
- [ ] AI instructions (`AGENTS.md` and its generated copies)
- [ ] Dependencies (`package.json` / `package-lock.json`)

## Related Issues

N/A

## How to Verify

Steps a reviewer can follow to confirm the change behaves as expected.

1. `npm ci`
2. `npm run start`, then open http://localhost:4200/
3. Verify

## Checklist

Mirror the CI pipeline in `.github/workflows/actions.yml` before requesting a review.

- [ ] Edited `AGENTS.md` (not the generated copies), then ran `npm run sync:agent-instructions`; `npm run sync:agent-instructions:check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (unit, scripts, and Playwright e2e)
- [x] `npm run build` succeeds
- [x] Tests added or updated to cover new or changed behavior
- [x] UI changes meet accessibility requirements (AXE clean, WCAG AA)
- [ ] Documentation updated where applicable
